### PR TITLE
Fix negated awaits

### DIFF
--- a/source/lib/auxiliary/file.ts
+++ b/source/lib/auxiliary/file.ts
@@ -41,7 +41,7 @@ export namespace File {
         try {
             const encoding: BufferEncoding = 'utf-8';
             log({ message: `Opening file path, ${filePath}, in read mode`, color: white });
-            const cantReadFile: boolean = await !(isFileReadable({ filePath }));
+            const cantReadFile: boolean = !(await isFileReadable({ filePath }));
             if (cantReadFile)
                 throw new Error(`File is not readable, is missing or corrupted`);
             const fileHandle: FileHandle = await open(filePath);
@@ -83,7 +83,7 @@ export namespace File {
         { filePath: string; }): Promise<Buffer> {
         try {
             log({ message: `Opening file path, ${filePath}, in read mode`, color: white });
-            if (await !(isFileReadable({ filePath })))
+            if (!(await isFileReadable({ filePath })))
                 throw new Error(`File is not readable, is missing or corrupted`);
             const fileHandle: FileHandle = await open(filePath);
             log({ message: 'Getting file size', color: white });
@@ -124,7 +124,7 @@ export namespace File {
     }): Promise<number> {
         try {
             log({ message: `Opening file path, ${filePath}, in write mode`, color: white });
-            if (await !(isFileWritable({ filePath })))
+            if (!(await isFileWritable({ filePath })))
                 throw new Error(`File is not writable, is missing or corrupted`);
             const flags: string = 'w';
             const fileHandle: fs.FileHandle = await fs.open(filePath, flags);

--- a/source/lib/configuration/configuration.ts
+++ b/source/lib/configuration/configuration.ts
@@ -42,7 +42,7 @@ export namespace Configuration {
         { filePath?: string }): Promise<ConfigurationObject> {
         try {
             const encoding: BufferEncoding = CONFIG_ENCODING;
-            const cantReadFile: boolean = await !(isFileReadable({ filePath }));
+            const cantReadFile: boolean = !(await isFileReadable({ filePath }));
             if (cantReadFile)
                 throw new Error(`Configuration file is not readable, is missing or corrupted`);
             const fileHandle: fs.FileHandle = await fs.open(filePath);


### PR DESCRIPTION
## Summary
- fix negated awaits in File and Configuration modules
- run TypeScript build

## Testing
- `npm run ts-build` *(fails: Cannot find module 'path' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685ae85ecdfc8325b7c698a82f059562