### PR TITLE
Remove BOMs from TypeScript sources

### DIFF
--- a/source/lib/auxiliary/file.ts
+++ b/source/lib/auxiliary/file.ts
@@ -1,4 +1,4 @@
-﻿import * as fs from 'fs/promises';
+import * as fs from 'fs/promises';
 import { open } from 'fs/promises';
 
 import BufferWrappers from '../patches/buffer.wrappers.js';

--- a/source/lib/auxiliary/file.wrappers.ts
+++ b/source/lib/auxiliary/file.wrappers.ts
@@ -1,4 +1,4 @@
-﻿import { Stats } from 'fs';
+import { Stats } from 'fs';
 import { access, constants, copyFile, unlink, rm, readdir, open } from 'fs/promises';
 import { basename } from 'path';
 

--- a/source/lib/auxiliary/uac.ts
+++ b/source/lib/auxiliary/uac.ts
@@ -1,4 +1,4 @@
-﻿import { exit } from 'process';
+import { exit } from 'process';
 
 import * as isElevated from 'elevated';
 

--- a/source/lib/configuration/constants.ts
+++ b/source/lib/configuration/constants.ts
@@ -1,4 +1,4 @@
-﻿import sevenBin from '7zip-bin';
+import sevenBin from '7zip-bin';
 import { Encoding, CipherGCMTypes } from 'crypto';
 
 import {

--- a/source/lib/patches/buffer.wrappers.ts
+++ b/source/lib/patches/buffer.wrappers.ts
@@ -1,4 +1,4 @@
-﻿import Debug from '../auxiliary/debug.js';
+import Debug from '../auxiliary/debug.js';
 const { log } = Debug;
 
 import colorsCli from 'colors-cli';

--- a/source/lib/patches/parser.ts
+++ b/source/lib/patches/parser.ts
@@ -1,4 +1,4 @@
-﻿import ParserWrappers from './parser.wrappers.js';
+import ParserWrappers from './parser.wrappers.js';
 const { hexParse, splitLines } = ParserWrappers;
 
 import Debug from '../auxiliary/debug.js';

--- a/source/lib/patches/parser.wrappers.ts
+++ b/source/lib/patches/parser.wrappers.ts
@@ -1,4 +1,4 @@
-﻿import Debug from '../auxiliary/debug.js';
+import Debug from '../auxiliary/debug.js';
 const { log } = Debug;
 
 import colorsCli from 'colors-cli';


### PR DESCRIPTION
## Summary
- strip UTF-8 BOM characters from TypeScript files under `source/`

## Testing
- `npm run ts-build` *(fails: Cannot find module 'path' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685ae82a1e848325a9db1692f850c591