### PR TITLE
Fix disableDebug export

### DIFF
--- a/source/lib/auxiliary/debug.ts
+++ b/source/lib/auxiliary/debug.ts
@@ -62,7 +62,7 @@ export namespace Debug {
             return false;
         }
     }
-    export const disableDebug = disable();
+    export const disableDebug = disable;
 
     /**
      * Check if debugging is enabled


### PR DESCRIPTION
## Summary
- correct disableDebug export so it references the function

## Testing
- `npm run ts-build` *(fails: cannot find modules and types)*

------
https://chatgpt.com/codex/tasks/task_e_685ae8333c448325a35943bd1c6da14b