### PR TITLE
Add Jest unit tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+export default {
+  testEnvironment: 'node'
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@types/debug": "^4.1.8",
         "@types/node": "^20.4.0",
         "@types/node-7z": "^2.1.5",
+        "jest": "^30.0.2",
         "typedoc": "^0.24.8",
         "typescript": "^5.1.6"
       }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@types/debug": "^4.1.8",
     "@types/node": "^20.4.0",
     "@types/node-7z": "^2.1.5",
+    "jest": "^30.0.2",
     "typedoc": "^0.24.8",
     "typescript": "^5.1.6"
   },
@@ -55,7 +56,8 @@
     "sea-copy-patch_files": "xcopy .\\patch_files\\* .\\sea\\predist\\patch_files\\ /E /S /V /D /Y",
     "sea-copy-7z": "xcopy .\\node_modules\\7zip-bin\\win\\* .\\sea\\predist\\win\\ /E /S /V /D /Y",
     "generate-docs": "npx typedoc source/",
-    "start": "node ./dist/standalone/executable.js"
+    "start": "node ./dist/standalone/executable.js",
+    "test": "npm run ts-build && NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "scriptsComments": {
     "#GENERAL SCRIPTS#": "#SECTION#",

--- a/test/buffer.test.js
+++ b/test/buffer.test.js
@@ -1,0 +1,23 @@
+import { BufferUtils } from '../dist/lib/patches/buffer.js';
+
+describe('BufferUtils.patchBuffer', () => {
+  test('patches buffer value', () => {
+    const buf = Buffer.from([0x00, 0x01]);
+    const patched = BufferUtils.patchBuffer({
+      buffer: buf,
+      offset: 0,
+      previousValue: 0x00,
+      newValue: 0xff,
+      options: {
+        forcePatch: false,
+        unpatchMode: false,
+        nullPatch: false,
+        failOnUnexpectedPreviousValue: false,
+        warnOnUnexpectedPreviousValue: false,
+        skipWritePatch: false
+      }
+    });
+    expect(patched[0]).toBe(0xff);
+    expect(patched).toBe(buf);
+  });
+});

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -1,0 +1,12 @@
+import { Parser } from '../dist/lib/patches/parser.js';
+
+describe('Parser.parsePatchFile', () => {
+  test('parses patch data into objects', async () => {
+    const data = '00000000: 00 01\n00000001: 02 03';
+    const patches = await Parser.parsePatchFile({ fileData: data });
+    expect(patches).toEqual([
+      { offset: 0x00000000, previousValue: 0x00, newValue: 0x01 },
+      { offset: 0x00000001, previousValue: 0x02, newValue: 0x03 }
+    ]);
+  });
+});

--- a/test/patches.test.js
+++ b/test/patches.test.js
@@ -1,0 +1,39 @@
+import { Patches } from '../dist/lib/patches/patches.js';
+import { ConfigurationDefaults } from '../dist/lib/configuration/configuration.defaults.js';
+import fs from 'fs';
+
+const patchDir = 'patch_files';
+const testPatchPath = `${patchDir}\\test.patch`;
+const testBinPath = 'test/tmp.bin';
+
+describe('Patches.runPatches', () => {
+  beforeAll(() => {
+    fs.mkdirSync('test', { recursive: true });
+    fs.mkdirSync(patchDir, { recursive: true });
+    fs.writeFileSync(testBinPath, Buffer.from([0x00]));
+    fs.writeFileSync(testPatchPath, '00000000: 00 ff\n');
+  });
+
+  afterAll(() => {
+    fs.rmSync(testBinPath, { force: true });
+    fs.rmSync(testPatchPath, { force: true });
+  });
+
+  test('patches a binary file', async () => {
+    const config = ConfigurationDefaults.getDefaultConfigurationObject();
+    config.patches = [
+      { name: 'test', patchFilename: 'test.patch', fileNamePath: testBinPath, enabled: true }
+    ];
+    const pOpts = config.options.patches;
+    pOpts.backupFiles = false;
+    pOpts.fileSizeCheck = false;
+    pOpts.skipWritingBinary = false;
+    pOpts.warnOnUnexpectedPreviousValue = false;
+    pOpts.failOnUnexpectedPreviousValue = false;
+    pOpts.runPatches = true;
+
+    await Patches.runPatches({ configuration: config });
+    const data = fs.readFileSync(testBinPath);
+    expect(data[0]).toBe(0xff);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest dev dependency and npm test script
- configure Jest to use the node environment
- add unit tests for Parser.parsePatchFile, BufferUtils.patchBuffer and Patches.runPatches

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ae84446648325a2aa0454d7cdf33b