### PR TITLE
Fix debug disabling functions

### DIFF
--- a/source/lib/auxiliary/debug.ts
+++ b/source/lib/auxiliary/debug.ts
@@ -62,7 +62,7 @@ export namespace Debug {
             return false;
         }
     }
-    export const disableDebug = disable();
+    export const disableDebug = disable;
 
     /**
      * Check if debugging is enabled
@@ -84,7 +84,7 @@ export namespace Debug {
         return debugStatus;
     }
     export const isDebuggingEnabled = isEnabled;
-    export const isDisabled = !isEnabled;
+    export function isDisabled(): boolean { return !isEnabled(); }
     export const isDebuggingDisabled = isDisabled;
 }
 


### PR DESCRIPTION
## Summary
- fix disableDebug to reference the function rather than executing it
- implement isDisabled as a function and reference it in isDebuggingDisabled
- ensure source/lib/auxiliary/debug.ts ends with a newline

## Testing
- `npm run ts-build` *(fails: Cannot find module 'path' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685ae86bcfc48325b1561855d1d281d2