### PR TITLE
Fix compression method option

### DIFF
--- a/source/lib/build/predist.ts
+++ b/source/lib/build/predist.ts
@@ -27,7 +27,7 @@ export namespace Predist {
             debug.enable({ logging: false });
             debug.log({ message: `Packaging ${seaArchiveName}`, color: white });
             const options: {} = {
-                method: [PACKMETHOD],
+                method: PACKMETHOD,
                 $bin: SEVENZIPBIN_FILEPATH
             };
             const packageStream: ZipStream = Seven.add(`./sea/${seaArchiveName}`, `./sea/predist/*`, options);

--- a/source/lib/filedrops/packer.ts
+++ b/source/lib/filedrops/packer.ts
@@ -49,7 +49,7 @@ export namespace Packer {
         const destinationPath: string = getPackedPath({ filePath: sourcePath });
         log({ message: `Pack destination path is ${destinationPath}`, color: white });
         const options: {} = {
-            method: [PACKMETHOD],
+            method: PACKMETHOD,
             $bin: SEVENZIPBIN_FILEPATH,
             password: password
         };


### PR DESCRIPTION
## Summary
- fix packFile and predistPackage 7z `method` option usage

## Testing
- `npm test` *(fails: cannot find Node built-in declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685bde227a148325835216b4e9ca2e95