### PR TITLE
Improve calling filename detection

### DIFF
--- a/source/lib/auxiliary/callee.ts
+++ b/source/lib/auxiliary/callee.ts
@@ -1,36 +1,44 @@
 import { basename } from 'path';
+import { fileURLToPath } from 'url';
 
 export namespace Callee {
     /**
      * @internal
-     * Get which filename is calling a function
-     * 
+     * Get the filename of the caller module using stack inspection
+     * and {@link import.meta.url}.
+     *
      * @example
      * ```
      * getCallingFilename();
      * ```
-     * @returns A filename calling the function or null on failure
+     * @returns Base filename of the caller or `null` on failure
      * @since 0.0.1
      */
     export function getCallingFilename(): string | null {
         try {
             const stack: string | undefined = new Error().stack;
             if (stack) {
-                const newLineBreak: string = '\n';
-                const lineToRemove: number = 1;
-                const stackLines: string[] = stack.split(newLineBreak).slice(lineToRemove);
-                const firstLevelCalleeLine: string | undefined = stackLines.find(function (line) {
-                    const functionName: string = 'getCallingFilename';
-                    return !line.includes(functionName);
+                const stackLines: string[] = stack.split('\n');
+                const thisFile: string = fileURLToPath(import.meta.url);
+                const thisIndex: number = stackLines.findIndex(function (line) {
+                    return line.includes(thisFile);
                 });
-                if (firstLevelCalleeLine !== null && firstLevelCalleeLine !== undefined) {
-                    const secondLevelCalleeLine: string | undefined = stackLines[stackLines.indexOf(firstLevelCalleeLine) + 1];
-                    if (secondLevelCalleeLine !== null && secondLevelCalleeLine !== undefined) {
-                        const matchingRegExp: RegExp = /\((.*):\d+:\d+\)/;
-                        const filenameMatch: RegExpMatchArray | null = secondLevelCalleeLine.match(matchingRegExp);
+                if (thisIndex !== -1) {
+                    let callerLine: string | undefined;
+                    for (let i = thisIndex + 1; i < stackLines.length; i++) {
+                        const line: string = stackLines[i];
+                        if (!line.includes(thisFile)) {
+                            callerLine = line;
+                            break;
+                        }
+                    }
+                    if (callerLine) {
+                        const matchingRegExp: RegExp = /\((.*):\d+:\d+\)|at (.*):\d+:\d+$/;
+                        const filenameMatch: RegExpMatchArray | null = callerLine.match(matchingRegExp);
                         if (filenameMatch !== null) {
-                            const filename: string = filenameMatch[1];
-                            return basename(filename);
+                            const filename: string | undefined = filenameMatch[1] ?? filenameMatch[2];
+                            if (filename)
+                                return basename(fileURLToPath(filename));
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- rewrite `getCallingFilename` to use `import.meta.url` and `fileURLToPath`
- document updated behaviour

## Testing
- `npm test` *(fails: unsupported platform)*

------
https://chatgpt.com/codex/tasks/task_e_685be0631c2c83259da5e4e700f21526