### PR TITLE
Fix general commands execution

### DIFF
--- a/source/lib/commands/commands.ts
+++ b/source/lib/commands/commands.ts
@@ -113,7 +113,7 @@ export namespace Commands {
         for (const command of commands)
             if (command.enabled === true) {
                 log({ message: `Running general command ${command.name}: ${command.command}`, color: white });
-                await runCommand({ command: command.name, parameters: '' });
+                await runCommand({ command: command.command, parameters: '' });
             }
     }
 }


### PR DESCRIPTION
## Summary
- make `runCommandsGeneral` invoke `runCommand` with the correct command string

## Testing
- `npm test` *(fails: unsupported platform)*

------
https://chatgpt.com/codex/tasks/task_e_685be4b4df048325abc55405705ee150