### PR TITLE
Fix parser splitLines for CRLF

### DIFF
--- a/source/lib/patches/parser.wrappers.ts
+++ b/source/lib/patches/parser.wrappers.ts
@@ -43,7 +43,7 @@ export namespace ParserWrappers {
     export function splitLines({ fileData }:
         { fileData: string }): Array<string> {
         try {
-            const patchData: Array<string> = fileData.split('\n');
+            const patchData: Array<string> = fileData.split(/\r?\n/);
             return patchData;
         } catch (error: any) {
             log({ message: `An error has occurred ${error}`, color: red_bt });


### PR DESCRIPTION
## Summary
- handle Windows patch files with CRLF endings in `splitLines`
- compile and run tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bf8c421148325b76c1274b85c8870