### PR TITLE
Configure ts-jest and update tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,7 @@
 export default {
-  testEnvironment: 'node'
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1'
+  }
 };

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/node": "^20.4.0",
     "@types/node-7z": "^2.1.5",
     "jest": "^30.0.2",
+    "ts-jest": "^29.1.1",
     "typedoc": "^0.24.8",
     "typescript": "^5.1.6"
   },
@@ -57,7 +58,7 @@
     "sea-copy-7z": "xcopy .\\node_modules\\7zip-bin\\win\\* .\\sea\\predist\\win\\ /E /S /V /D /Y",
     "generate-docs": "npx typedoc source/",
     "start": "node ./dist/standalone/executable.js",
-    "test": "npm run ts-build && NODE_OPTIONS=--experimental-vm-modules jest"
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "scriptsComments": {
     "#GENERAL SCRIPTS#": "#SECTION#",

--- a/test/buffer.test.js
+++ b/test/buffer.test.js
@@ -1,4 +1,4 @@
-import { BufferUtils } from '../dist/lib/patches/buffer.js';
+import { BufferUtils } from '../source/lib/patches/buffer.ts';
 
 describe('BufferUtils.patchBuffer', () => {
   test('patches buffer value', () => {

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -1,4 +1,4 @@
-import { Parser } from '../dist/lib/patches/parser.js';
+import { Parser } from '../source/lib/patches/parser.ts';
 
 describe('Parser.parsePatchFile', () => {
   test('parses patch data into objects', async () => {

--- a/test/patches.test.js
+++ b/test/patches.test.js
@@ -1,5 +1,5 @@
-import { Patches } from '../dist/lib/patches/patches.js';
-import { ConfigurationDefaults } from '../dist/lib/configuration/configuration.defaults.js';
+import { Patches } from '../source/lib/patches/patches.ts';
+import { ConfigurationDefaults } from '../source/lib/configuration/configuration.defaults.ts';
 import fs from 'fs';
 
 const patchDir = 'patch_files';


### PR DESCRIPTION
## Summary
- add `ts-jest` dev dependency
- configure Jest to use `ts-jest` with ESM
- update tests to reference TypeScript sources
- simplify test script to skip build step

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c1762816c83259da3e88bed982189