### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,0 +1,20 @@
+name: Node.js CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        node-version: [18, 20]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm test


### PR DESCRIPTION
## Summary
- run CI for Node.js versions 18 and 20 using GitHub Actions

## Testing
- `npm test` *(fails: Cannot find module '@types/node', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685c1ec7ce6c832595b7652f1eb64f2d