### PR TITLE
Add CLI config option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,7 @@ Simple running example
 import { Patcher } from 'patcherjs';
 
 Patcher.runPatcher({});
+Patcher.runPatcher({ configFilePath: './my-config.json' });
 ```
 
 ### Use as standalone application or development
@@ -44,7 +45,11 @@ Download from releases or clone the repository
 ```
 $ git clone https://github.com/supermarsx/patcherjs
 $ npm install
+$ npm run ts-build
+$ node dist/standalone/executable.js
+$ node dist/standalone/executable.js --config ./my-config.json
 ```
+The `--config` option allows you to specify a custom configuration file instead of the default `config.json`.
 #### npm scripts
 
 There are a collection of scripts that are used help manage the build process

--- a/source/standalone/executable.ts
+++ b/source/standalone/executable.ts
@@ -1,5 +1,15 @@
 import Patcher from '../index.js';
 const { runPatcher } = Patcher;
 
+function getConfigPathFromArgs(args: string[]): string | undefined {
+  const index = args.indexOf('--config');
+  if (index !== -1 && index + 1 < args.length) {
+    return args[index + 1];
+  }
+  return undefined;
+}
+
+const configFilePath = getConfigPathFromArgs(process.argv.slice(2));
+
 /** Just run the patcher */
-runPatcher({});
+runPatcher({ configFilePath });


### PR DESCRIPTION
## Summary
- add command-line parsing in executable
- document CLI usage and config override

## Testing
- `npm test` *(fails: Cannot find module 'fs/promises' or its corresponding type declarations)*
- `npm run lint` *(fails: ESLint couldn't find the plugin "@typescript-eslint/eslint-plugin")*

------
https://chatgpt.com/codex/tasks/task_e_685c1ed6c87c8325b7e2cce3e70ca8a0