### PR TITLE
Add tests for Commands and Filedrops

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 export default {
   preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
+  restoreMocks: true,
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1'
   }

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -1,0 +1,68 @@
+import { jest } from '@jest/globals';
+import { ConfigurationDefaults } from '../source/lib/configuration/configuration.defaults.ts';
+
+jest.unstable_mockModule('../source/lib/commands/commands.taskschd.js', () => ({
+  default: { runCommandsTaskScheduler: jest.fn() }
+}));
+
+jest.unstable_mockModule('../source/lib/commands/commands.services.js', () => ({
+  default: { runCommandsServices: jest.fn() }
+}));
+
+jest.unstable_mockModule('../source/lib/commands/commands.kill.js', () => ({
+  default: { runCommandsKill: jest.fn() }
+}));
+
+jest.unstable_mockModule('../source/lib/commands/command.js', () => ({
+  default: { runCommand: jest.fn() }
+}));
+
+let Commands;
+let CommandsTaskSchd;
+let CommandsServices;
+let CommandsKill;
+let Command;
+
+beforeAll(async () => {
+  Commands = (await import('../source/lib/commands/commands.ts')).Commands;
+  CommandsTaskSchd = await import('../source/lib/commands/commands.taskschd.js');
+  CommandsServices = await import('../source/lib/commands/commands.services.js');
+  CommandsKill = await import('../source/lib/commands/commands.kill.js');
+  Command = await import('../source/lib/commands/command.js');
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('Commands.runCommands', () => {
+  test('dispatches command types in order', async () => {
+    const config = ConfigurationDefaults.getDefaultConfigurationObject();
+    config.commands = { tasks: [], services: [], kill: [], general: [] };
+    await Commands.runCommands({ configuration: config });
+    expect(CommandsTaskSchd.default.runCommandsTaskScheduler).toHaveBeenCalled();
+    expect(CommandsServices.default.runCommandsServices).toHaveBeenCalled();
+    expect(CommandsKill.default.runCommandsKill).toHaveBeenCalled();
+    expect(Command.default.runCommand).not.toHaveBeenCalled();
+  });
+});
+
+describe('Commands.runCommandsGeneral', () => {
+  test('runs enabled general commands', async () => {
+    const config = ConfigurationDefaults.getDefaultConfigurationObject();
+    config.commands.general = [
+      { name: 'test', command: 'echo hi', enabled: true }
+    ];
+    await Commands.runCommandsGeneral({ configuration: config });
+    expect(Command.default.runCommand).toHaveBeenCalledWith({ command: 'echo hi', parameters: '' });
+  });
+
+  test('skips disabled general commands', async () => {
+    const config = ConfigurationDefaults.getDefaultConfigurationObject();
+    config.commands.general = [
+      { name: 'test', command: 'echo hi', enabled: false }
+    ];
+    await Commands.runCommandsGeneral({ configuration: config });
+    expect(Command.default.runCommand).not.toHaveBeenCalled();
+  });
+});

--- a/test/filedrops.test.js
+++ b/test/filedrops.test.js
@@ -1,0 +1,54 @@
+import { jest } from '@jest/globals';
+import { ConfigurationDefaults } from '../source/lib/configuration/configuration.defaults.ts';
+
+jest.unstable_mockModule('../source/lib/filedrops/crypt.js', () => ({
+  default: { decryptFile: jest.fn(async () => Buffer.from('decrypted')) }
+}));
+
+jest.unstable_mockModule('../source/lib/filedrops/packer.js', () => ({
+  default: { unpackFile: jest.fn(async () => Buffer.from('unpacked')) }
+}));
+
+jest.unstable_mockModule('../source/lib/auxiliary/file.js', () => ({
+  default: {
+    backupFile: jest.fn(),
+    readBinaryFile: jest.fn(async () => Buffer.from('binary')),
+    writeBinaryFile: jest.fn(async () => {})
+  }
+}));
+
+let Filedrops;
+let Crypt;
+let Packer;
+let File;
+
+beforeAll(async () => {
+  Filedrops = (await import('../source/lib/filedrops/filedrops.ts')).Filedrops;
+  Crypt = await import('../source/lib/filedrops/crypt.js');
+  Packer = await import('../source/lib/filedrops/packer.js');
+  File = await import('../source/lib/auxiliary/file.js');
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('Filedrops.runFiledrops', () => {
+  test('decrypts, unpacks and writes files', async () => {
+    const config = ConfigurationDefaults.getDefaultConfigurationObject();
+    config.filedrops = [
+      { name: 'd', fileDropName: 'f.bin', packedFileName: 'f.pack', fileNamePath: 'out.bin', decryptKey: 'key', enabled: true }
+    ];
+    const opts = config.options.filedrops;
+    opts.runFiledrops = true;
+    opts.isFiledropPacked = true;
+    opts.isFiledropCrypted = true;
+    opts.backupFiles = false;
+    await Filedrops.runFiledrops({ configuration: config });
+    expect(Crypt.default.decryptFile).toHaveBeenCalledWith({ filePath: expect.stringContaining('patch_files'), key: 'key' });
+    expect(Packer.default.unpackFile).toHaveBeenCalledWith({ buffer: Buffer.from('decrypted'), password: 'key' });
+    expect(File.default.writeBinaryFile).toHaveBeenCalledWith({ filePath: 'out.bin', buffer: Buffer.from('unpacked') });
+    expect(File.default.readBinaryFile).not.toHaveBeenCalled();
+    expect(File.default.backupFile).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- test `Commands` dispatching and general command execution with mocks
- test `Filedrops.runFiledrops` decrypt/unpack workflow with mocks
- reset mocks automatically via jest config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c1eaada0883259f7b2b7f4cbbe0e7