### PR TITLE
Add packer and crypt tests

### DIFF
--- a/test/crypt.test.js
+++ b/test/crypt.test.js
@@ -1,0 +1,36 @@
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../source/lib/auxiliary/file.js', () => ({
+  default: {
+    readBinaryFile: jest.fn(async () => Buffer.from('file')), // used when encryptFile uses filePath
+    writeBinaryFile: jest.fn()
+  }
+}));
+
+let Crypt;
+let File;
+
+beforeAll(async () => {
+  Crypt = (await import('../source/lib/filedrops/crypt.ts')).Encryption;
+  File = await import('../source/lib/auxiliary/file.js');
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('Encryption.encryptFile and decryptFile', () => {
+  test('roundtrips buffer data', async () => {
+    const data = Buffer.from('secret');
+    const key = 'pass';
+    const encrypted = await Crypt.encryptFile({ buffer: data, key });
+    const decrypted = await Crypt.decryptFile({ buffer: encrypted, key });
+    expect(decrypted.equals(data)).toBe(true);
+  });
+
+  test('uses file input when encrypting', async () => {
+    const key = 'pw';
+    await Crypt.encryptFile({ filePath: 'a.bin', key });
+    expect(File.default.readBinaryFile).toHaveBeenCalledWith({ filePath: 'a.bin' });
+  });
+});

--- a/test/packer.test.js
+++ b/test/packer.test.js
@@ -1,0 +1,70 @@
+import { jest } from '@jest/globals';
+import { EventEmitter } from 'events';
+
+jest.unstable_mockModule('../source/lib/auxiliary/file.js', () => ({
+  default: {
+    deleteFile: jest.fn(async () => {}),
+    deleteFolder: jest.fn(async () => {}),
+    firstFilenameInFolder: jest.fn(async () => '/tmp/temp-extracted/file.bin'),
+    readBinaryFile: jest.fn(async () => Buffer.from('packed')),
+    writeBinaryFile: jest.fn(async () => {})
+  }
+}));
+
+jest.unstable_mockModule('tmp', () => ({
+  default: { tmpNameSync: jest.fn(() => '/tmp/temp') }
+}));
+
+jest.unstable_mockModule('node-7z', () => {
+  const mockEmitter = () => {
+    const e = new EventEmitter();
+    process.nextTick(() => e.emit('end'));
+    return e;
+  };
+  return {
+    default: {
+      add: jest.fn(() => mockEmitter()),
+      extractFull: jest.fn(() => mockEmitter())
+    },
+    ZipStream: EventEmitter
+  };
+});
+
+let Packer;
+let File;
+let Seven;
+
+beforeAll(async () => {
+  Packer = (await import('../source/lib/filedrops/packer.ts')).Packer;
+  File = await import('../source/lib/auxiliary/file.js');
+  Seven = await import('node-7z');
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('Packer.packFile', () => {
+  test('packs buffer and cleans up', async () => {
+    const buf = Buffer.from('data');
+    const result = await Packer.packFile({ buffer: buf, password: 'pw', preserveSource: false });
+    expect(File.default.writeBinaryFile).toHaveBeenCalledWith({ filePath: '/tmp/temp', buffer: buf });
+    expect(Seven.default.add).toHaveBeenCalled();
+    expect(File.default.deleteFile).toHaveBeenCalledWith({ filePath: '/tmp/temp.pack' });
+    expect(File.default.deleteFile).toHaveBeenCalledWith({ filePath: '/tmp/temp' });
+    expect(result).toEqual(Buffer.from('packed'));
+  });
+});
+
+describe('Packer.unpackFile', () => {
+  test('unpacks buffer archive and cleans up', async () => {
+    File.default.readBinaryFile.mockResolvedValueOnce(Buffer.from('unpacked'));
+    const buf = Buffer.from('archive');
+    const result = await Packer.unpackFile({ buffer: buf, password: 'pw' });
+    expect(File.default.writeBinaryFile).toHaveBeenCalledWith({ filePath: '/tmp/temp', buffer: buf });
+    expect(Seven.default.extractFull).toHaveBeenCalled();
+    expect(File.default.deleteFile).toHaveBeenCalledWith({ filePath: '/tmp/temp' });
+    expect(File.default.deleteFolder).toHaveBeenCalledWith({ folderPath: '/tmp/temp-extracted' });
+    expect(result).toEqual(Buffer.from('unpacked'));
+  });
+});


### PR DESCRIPTION
## Summary
- cover packFile/unpackFile with mocked fs and 7zip
- test encryptFile and decryptFile roundtrip

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c2966806c8325a03ebe77e2048c3b