### PR TITLE
Use path.join for patch directories

### DIFF
--- a/source/lib/build/packaging.ts
+++ b/source/lib/build/packaging.ts
@@ -13,6 +13,8 @@ const { log } = Debug;
 import colorsCli from "colors-cli";
 const { red_bt, white, green_bt } = colorsCli;
 
+import { join } from 'path';
+
 import {
     ConfigurationObject,
     FiledropsObject,
@@ -72,7 +74,7 @@ export namespace Packaging {
 
             var fileData: Buffer;
             const { isFiledropPacked, isFiledropCrypted } = filedropOptions;
-            const filePath: string = `${PATCHES_BASEUNPACKEDPATH}${filedrop.packedFileName}`;
+            const filePath: string = join(PATCHES_BASEUNPACKEDPATH, filedrop.packedFileName);
             fileData = await readBinaryFile({ filePath });
             if (isFiledropPacked === true)
                 fileData = await packFile({ buffer: fileData, password: filedrop.decryptKey })
@@ -80,7 +82,7 @@ export namespace Packaging {
                 fileData = await encryptFile({ buffer: fileData, key: filedrop.decryptKey });
 
             await writeBinaryFile({
-                filePath: `${PATCHES_BASEPATH}${filedrop.fileDropName}`, buffer: fileData
+                filePath: join(PATCHES_BASEPATH, filedrop.fileDropName), buffer: fileData
             });
             log({ message: `File was packed successfully`, color: green_bt });
         } catch (error) {

--- a/source/lib/configuration/constants.ts
+++ b/source/lib/configuration/constants.ts
@@ -1,5 +1,6 @@
 import sevenBin from '7zip-bin';
 import { Encoding, CipherGCMTypes } from 'crypto';
+import { join, sep } from 'path';
 
 import {
     CryptBufferSubsets
@@ -63,8 +64,8 @@ namespace Constants {
 
     // PATCHES
     export const PATCHES_BACKUPEXT: string = `.bak`;
-    export const PATCHES_BASEPATH: string = `patch_files\\`;
-    export const PATCHES_BASEUNPACKEDPATH: string = `patch_files_unpacked\\`;
+    export const PATCHES_BASEPATH: string = join('patch_files', sep);
+    export const PATCHES_BASEUNPACKEDPATH: string = join('patch_files_unpacked', sep);
 
     // COMMANDS TASKSCHEDULER
     export const COMM_TASKS_DELETE: string = `delete`;

--- a/source/lib/filedrops/filedrops.ts
+++ b/source/lib/filedrops/filedrops.ts
@@ -13,6 +13,8 @@ const { log } = Debug;
 import colorsCli from 'colors-cli';
 const { red_bt, white, green_bt } = colorsCli;
 
+import { join } from 'path';
+
 import { ConfigurationObject, FiledropsObject, FiledropsOptionsObject } from '../configuration/configuration.types.js';
 
 import Constants from '../configuration/constants.js';
@@ -61,7 +63,7 @@ export namespace Filedrops {
             await prefiledropChecksAndRoutines({ filedropOptions, filedrop });
             var fileData: Buffer;
             const { isFiledropPacked, isFiledropCrypted } = configuration.options.filedrops;
-            const filePath: string = `${PATCHES_BASEPATH}${filedrop.fileDropName}`;
+            const filePath: string = join(PATCHES_BASEPATH, filedrop.fileDropName);
             if (isFiledropCrypted === true)
                 fileData = await decryptFile({ filePath, key: filedrop.decryptKey });
             else

--- a/source/lib/patches/patches.ts
+++ b/source/lib/patches/patches.ts
@@ -4,6 +4,8 @@ const { log } = Debug;
 import colorsCli from 'colors-cli';
 const { red_bt, white } = colorsCli;
 
+import { join } from 'path';
+
 import File from '../auxiliary/file.js';
 const { backupFile, getFileSizeUsingPath, readBinaryFile, readPatchFile, writeBinaryFile } = File;
 
@@ -73,7 +75,7 @@ export namespace Patches {
             const patchOptions: PatchOptionsObject = configuration.options.patches;
 
             await prepatchChecksAndRoutines({ patchOptions, patch });
-            const patchFileData: string = await readPatchFile({ filePath: `${PATCHES_BASEPATH}${patch.patchFilename}` });
+            const patchFileData: string = await readPatchFile({ filePath: join(PATCHES_BASEPATH, patch.patchFilename) });
             const patchData: PatchArray = await parsePatchFile({ fileData: patchFileData });
             const filePath: string = patch.fileNamePath;
 


### PR DESCRIPTION
## Summary
- normalize patch folder paths using `path.join`
- join filenames to those paths with `join`

## Testing
- `npm run ts-build` *(fails: Cannot find module 'fs/promises')*

------
https://chatgpt.com/codex/tasks/task_e_685c3d282c2c8325b9aecc6dd3ea73dc