### PR TITLE
Fix patch paths for cross-platform use

### DIFF
--- a/source/lib/build/packaging.ts
+++ b/source/lib/build/packaging.ts
@@ -12,6 +12,7 @@ const { log } = Debug;
 
 import colorsCli from "colors-cli";
 const { red_bt, white, green_bt } = colorsCli;
+import { join } from 'path';
 
 import {
     ConfigurationObject,
@@ -72,7 +73,7 @@ export namespace Packaging {
 
             var fileData: Buffer;
             const { isFiledropPacked, isFiledropCrypted } = filedropOptions;
-            const filePath: string = `${PATCHES_BASEUNPACKEDPATH}${filedrop.packedFileName}`;
+            const filePath: string = join(PATCHES_BASEUNPACKEDPATH, filedrop.packedFileName);
             fileData = await readBinaryFile({ filePath });
             if (isFiledropPacked === true)
                 fileData = await packFile({ buffer: fileData, password: filedrop.decryptKey })
@@ -80,7 +81,7 @@ export namespace Packaging {
                 fileData = await encryptFile({ buffer: fileData, key: filedrop.decryptKey });
 
             await writeBinaryFile({
-                filePath: `${PATCHES_BASEPATH}${filedrop.fileDropName}`, buffer: fileData
+                filePath: join(PATCHES_BASEPATH, filedrop.fileDropName), buffer: fileData
             });
             log({ message: `File was packed successfully`, color: green_bt });
         } catch (error) {

--- a/source/lib/configuration/constants.ts
+++ b/source/lib/configuration/constants.ts
@@ -1,5 +1,6 @@
 import sevenBin from '7zip-bin';
 import { Encoding, CipherGCMTypes } from 'crypto';
+import { join } from 'path';
 
 import {
     CryptBufferSubsets
@@ -63,8 +64,8 @@ namespace Constants {
 
     // PATCHES
     export const PATCHES_BACKUPEXT: string = `.bak`;
-    export const PATCHES_BASEPATH: string = `patch_files\\`;
-    export const PATCHES_BASEUNPACKEDPATH: string = `patch_files_unpacked\\`;
+    export const PATCHES_BASEPATH: string = join('patch_files');
+    export const PATCHES_BASEUNPACKEDPATH: string = join('patch_files_unpacked');
 
     // COMMANDS TASKSCHEDULER
     export const COMM_TASKS_DELETE: string = `delete`;

--- a/source/lib/filedrops/filedrops.ts
+++ b/source/lib/filedrops/filedrops.ts
@@ -12,6 +12,7 @@ const { log } = Debug;
 
 import colorsCli from 'colors-cli';
 const { red_bt, white, green_bt } = colorsCli;
+import { join } from 'path';
 
 import { ConfigurationObject, FiledropsObject, FiledropsOptionsObject } from '../configuration/configuration.types.js';
 
@@ -61,7 +62,7 @@ export namespace Filedrops {
             await prefiledropChecksAndRoutines({ filedropOptions, filedrop });
             var fileData: Buffer;
             const { isFiledropPacked, isFiledropCrypted } = configuration.options.filedrops;
-            const filePath: string = `${PATCHES_BASEPATH}${filedrop.fileDropName}`;
+            const filePath: string = join(PATCHES_BASEPATH, filedrop.fileDropName);
             if (isFiledropCrypted === true)
                 fileData = await decryptFile({ filePath, key: filedrop.decryptKey });
             else

--- a/source/lib/patches/patches.ts
+++ b/source/lib/patches/patches.ts
@@ -24,6 +24,7 @@ import {
 } from './parser.types.js';
 
 import Constants from '../configuration/constants.js';
+import { join } from 'path';
 const {
     PATCHES_BASEPATH
 } = Constants;
@@ -73,7 +74,7 @@ export namespace Patches {
             const patchOptions: PatchOptionsObject = configuration.options.patches;
 
             await prepatchChecksAndRoutines({ patchOptions, patch });
-            const patchFileData: string = await readPatchFile({ filePath: `${PATCHES_BASEPATH}${patch.patchFilename}` });
+            const patchFileData: string = await readPatchFile({ filePath: join(PATCHES_BASEPATH, patch.patchFilename) });
             const patchData: PatchArray = await parsePatchFile({ fileData: patchFileData });
             const filePath: string = patch.fileNamePath;
 

--- a/test/patches.test.js
+++ b/test/patches.test.js
@@ -1,9 +1,10 @@
 import { Patches } from '../source/lib/patches/patches.ts';
 import { ConfigurationDefaults } from '../source/lib/configuration/configuration.defaults.ts';
 import fs from 'fs';
+import { join } from 'path';
 
-const patchDir = 'patch_files';
-const testPatchPath = `${patchDir}\\test.patch`;
+const patchDir = join('patch_files');
+const testPatchPath = join(patchDir, 'test.patch');
 const testBinPath = 'test/tmp.bin';
 
 describe('Patches.runPatches', () => {


### PR DESCRIPTION
## Summary
- replace Windows-style patch paths with `path.join`
- use `path.join` when building patch file paths
- update patch test path construction

## Testing
- `npm test` *(fails: unsupported platform)*

------
https://chatgpt.com/codex/tasks/task_e_685c49bed1fc83258445b1e07af7bc7c