### PR TITLE
Fix builder on non-windows

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -101,6 +101,9 @@ $ npm run sea-build-full-clean
 ```
 2. Grab your file from `sea/dist` folder if you want a single executable otherwise grab all files from `sea/predist` if you prefer a multi file approach.
 
+> **Note**
+> The build pipeline expects a Windows environment and uses `signtool` to remove the signature from the copied Node binary. When running on other platforms this step is skipped and the resulting executable will remain unsigned.
+
 #### Project structure
 
 `Project folder`

--- a/source/lib/build/builder.ts
+++ b/source/lib/build/builder.ts
@@ -30,14 +30,20 @@ export namespace Builder {
         await runCommand({ command: nodeBin, parameters: blobParameters });
 
         debug.log({ message: `Copying node binary`, color: white });
-        const binaryName: string = `./sea/predist/patcherjs.exe`;
+        const binaryName: string = process.platform === 'win32'
+            ? `./sea/predist/patcherjs.exe`
+            : `./sea/predist/patcherjs`;
         const nodeCopyParameters: string = `-e "require('fs').copyFileSync(process.execPath, '${binaryName}')"`;
         await runCommand({ command: nodeBin, parameters: nodeCopyParameters });
 
-        debug.log({ message: `Removing signature`, color: white });
-        const signtoolBin: string = `signtool`;
-        const signtoolUnsigningParameters: string = `remove /s ${binaryName}`;
-        await runCommand({ command: signtoolBin, parameters: signtoolUnsigningParameters });
+        if (process.platform === 'win32') {
+            debug.log({ message: `Removing signature`, color: white });
+            const signtoolBin: string = `signtool`;
+            const signtoolUnsigningParameters: string = `remove /s ${binaryName}`;
+            await runCommand({ command: signtoolBin, parameters: signtoolUnsigningParameters });
+        } else {
+            debug.log({ message: `Skipping signature removal step on non-Windows platform`, color: white });
+        }
 
         debug.log({ message: `Injecting script`, color: white });
         const npxBin: string = `npx`;

--- a/source/lib/build/packaging.ts
+++ b/source/lib/build/packaging.ts
@@ -14,8 +14,6 @@ import colorsCli from "colors-cli";
 const { red_bt, white, green_bt } = colorsCli;
 import { join } from 'path';
 
-import { join } from 'path';
-
 import {
     ConfigurationObject,
     FiledropsObject,

--- a/source/lib/filedrops/filedrops.ts
+++ b/source/lib/filedrops/filedrops.ts
@@ -14,8 +14,6 @@ import colorsCli from 'colors-cli';
 const { red_bt, white, green_bt } = colorsCli;
 import { join } from 'path';
 
-import { join } from 'path';
-
 import { ConfigurationObject, FiledropsObject, FiledropsOptionsObject } from '../configuration/configuration.types.js';
 
 import Constants from '../configuration/constants.js';

--- a/source/lib/patches/patches.ts
+++ b/source/lib/patches/patches.ts
@@ -4,6 +4,7 @@ const { log } = Debug;
 import colorsCli from 'colors-cli';
 const { red_bt, white } = colorsCli;
 
+
 import { join } from 'path';
 
 import File from '../auxiliary/file.js';
@@ -26,7 +27,6 @@ import {
 } from './parser.types.js';
 
 import Constants from '../configuration/constants.js';
-import { join } from 'path';
 const {
     PATCHES_BASEPATH
 } = Constants;


### PR DESCRIPTION
## Summary
- ensure builder.ts only calls signtool on Windows
- document the Windows only build step
- fix duplicated imports in patches, filedrops and packaging modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c5522185483258229f75a01785b72