### PR TITLE
Fix workflow OS matrix

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -6,10 +6,11 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
     strategy:
       matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
         node-version: [18, 20]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
## Summary
- enable cross-platform testing in Node.js workflow

## Testing
- `npm install`
- `npm test` *(fails: Duplicate identifier 'join')*

------
https://chatgpt.com/codex/tasks/task_e_685c56863ad08325b07916f822ced6c6