### PR TITLE
Add platform checks for command utilities

### DIFF
--- a/source/lib/commands/commands.kill.ts
+++ b/source/lib/commands/commands.kill.ts
@@ -14,7 +14,8 @@ import {
 
 import Constants from '../configuration/constants.js';
 const {
-    TASKKILL_BIN
+    TASKKILL_BIN,
+    IS_WINDOWS
 } = Constants;
 
 export namespace CommandsKill {
@@ -79,7 +80,9 @@ export namespace CommandsKill {
         { taskName: string }): Promise<string | null> {
 
         const command: string = TASKKILL_BIN;
-        const parameters: string = `/f /im \"${taskName}\"`;
+        const parameters: string = IS_WINDOWS
+            ? `/f /im \"${taskName}\"`
+            : `-9 $(pgrep -f \"${taskName}\")`;
         const result: string | null = await runCommand({ command, parameters });
         return result;
     }

--- a/source/lib/commands/commands.services.ts
+++ b/source/lib/commands/commands.services.ts
@@ -17,7 +17,9 @@ const {
     COMM_SERVICES_DISABLE,
     COMM_SERVICES_REMOVE,
     COMM_SERVICES_STOP,
-    SERVICE_BIN
+    SERVICE_BIN,
+    IS_WINDOWS,
+    IS_MACOS
 } = Constants;
 
 export namespace CommandsServices {
@@ -106,7 +108,9 @@ export namespace CommandsServices {
         { serviceName: string }): Promise<string | null> {
 
         const command: string = SERVICE_BIN;
-        const parameters: string = `stop ${serviceName}`;
+        const parameters: string = IS_WINDOWS
+            ? `stop ${serviceName}`
+            : `stop ${serviceName}`;
         const result: string | null = await runCommand({ command, parameters });
         return result;
     }
@@ -130,7 +134,9 @@ export namespace CommandsServices {
         { serviceName: string }): Promise<string | null> {
 
         const command: string = SERVICE_BIN;
-        const parameters: string = `config ${serviceName} start= disabled`;
+        const parameters: string = IS_WINDOWS
+            ? `config ${serviceName} start= disabled`
+            : `disable ${serviceName}`;
         const result: string | null = await runCommand({ command, parameters });
         return result;
     }
@@ -155,7 +161,11 @@ export namespace CommandsServices {
         { serviceName: string }): Promise<string | null> {
 
         const command: string = SERVICE_BIN;
-        const parameters: string = `delete ${serviceName}`;
+        const parameters: string = IS_WINDOWS
+            ? `delete ${serviceName}`
+            : IS_MACOS
+                ? `remove ${serviceName}`
+                : `disable --now ${serviceName}`;
         const result: string | null = await runCommand({ command, parameters });
         return result;
     }

--- a/source/lib/commands/commands.taskschd.ts
+++ b/source/lib/commands/commands.taskschd.ts
@@ -16,7 +16,9 @@ import Constants from '../configuration/constants.js';
 const {
     COMM_TASKS_DELETE,
     COMM_TASKS_STOP,
-    TASKSCHD_BIN
+    TASKSCHD_BIN,
+    IS_WINDOWS,
+    IS_MACOS
 } = Constants;
 
 export namespace CommandsTaskscheduler {
@@ -89,7 +91,11 @@ export namespace CommandsTaskscheduler {
     export async function remove({ taskName }:
         { taskName: string }): Promise<string | null> {
         const command: string = TASKSCHD_BIN;
-        const parameters: string = `/delete /f /tn \"${taskName}\"`;
+        const parameters: string = IS_WINDOWS
+            ? `/delete /f /tn \"${taskName}\"`
+            : IS_MACOS
+                ? `remove ${taskName}`
+                : `disable --now ${taskName}`;
         const result: string | null = await runCommand({ command, parameters });
         return result;
     }
@@ -112,7 +118,9 @@ export namespace CommandsTaskscheduler {
     export async function stop({ taskName }:
         { taskName: string }): Promise<string | null> {
         const command: string = TASKSCHD_BIN;
-        const parameters: string = `/end /tn \"${taskName}\"`;
+        const parameters: string = IS_WINDOWS
+            ? `/end /tn \"${taskName}\"`
+            : `stop ${taskName}`;
         const result: string | null = await runCommand({ command, parameters });
         return result;
     }

--- a/source/lib/configuration/constants.ts
+++ b/source/lib/configuration/constants.ts
@@ -9,14 +9,27 @@ import {
 const { floor, random } = Math;
 
 namespace Constants {
+    /** Operating system checks */
+    export const IS_WINDOWS: boolean = process.platform === 'win32';
+    export const IS_MACOS: boolean = process.platform === 'darwin';
+    export const IS_UBUNTU: boolean = process.platform === 'linux';
+
     /** Task scheduler application binary name */
-    export const TASKSCHD_BIN: string = `schtasks.exe`;
+    export const TASKSCHD_BIN: string = IS_WINDOWS
+        ? `schtasks.exe`
+        : IS_MACOS
+            ? `launchctl`
+            : `systemctl`;
 
     /** System services application binary name */
-    export const SERVICE_BIN: string = `sc.exe`;
+    export const SERVICE_BIN: string = IS_WINDOWS
+        ? `sc.exe`
+        : IS_MACOS
+            ? `launchctl`
+            : `systemctl`;
 
     /** Task kill binary name */
-    export const TASKKILL_BIN: string = `taskkill.exe`;
+    export const TASKKILL_BIN: string = IS_WINDOWS ? `taskkill.exe` : `kill`;
 
     /** Debugging name environment variable names */
     /** Debugging env var name */


### PR DESCRIPTION
## Summary
- support macOS and Ubuntu binaries in constants
- adjust service remove and task remove commands for macOS

## Testing
- `npm run lint` *(fails: numerous lint errors)*
- `npm test` *(fails: TypeScript compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_685c5622facc83258b902f261df03d9d