### PR TITLE
Fix path handling in patches

### DIFF
--- a/source/lib/auxiliary/file.wrappers.ts
+++ b/source/lib/auxiliary/file.wrappers.ts
@@ -1,6 +1,6 @@
 import { Stats } from 'fs';
 import { access, constants, copyFile, unlink, rm, readdir, open } from 'fs/promises';
-import { basename } from 'path';
+import { basename, join } from 'path';
 
 import { FileHandle } from 'fs/promises';
 
@@ -207,7 +207,7 @@ export namespace FileWrappers {
         return new Promise(function (resolve, reject) {
             readdir(folderPath)
                 .then(function (filenames) {
-                    const completeFilePath: string = `${folderPath}\\${filenames[0]}`;
+                    const completeFilePath: string = join(folderPath, filenames[0]);
                     resolve(completeFilePath);
                 }).catch(function (error) {
                     reject(error);

--- a/test/patches.test.js
+++ b/test/patches.test.js
@@ -5,7 +5,7 @@ import { join } from 'path';
 
 const patchDir = join('patch_files');
 const testPatchPath = join(patchDir, 'test.patch');
-const testBinPath = 'test/tmp.bin';
+const testBinPath = join('test', 'tmp.bin');
 
 describe('Patches.runPatches', () => {
   beforeAll(() => {


### PR DESCRIPTION
## Summary
- build test binary path using `path.join`
- join directory and filename in `FileWrappers.firstFilenameInFolder`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c60f3d8588325854a79e766f91e82