### PR TITLE
Add support for 64bit patch offsets

### DIFF
--- a/config.json
+++ b/config.json
@@ -29,7 +29,8 @@
       "unpatchMode": false,
       "verifyPatch": true,
       "backupFiles": true,
-      "skipWritingBinary": false
+      "skipWritingBinary": false,
+      "use64BitOffsets": false
     },
     "commands": {
       "runCommands": true

--- a/source/lib/configuration/configuration.defaults.ts
+++ b/source/lib/configuration/configuration.defaults.ts
@@ -46,6 +46,7 @@ export namespace ConfigurationDefaults {
                     verifyPatch: true,
                     backupFiles: true,
                     skipWritingBinary: false,
+                    use64BitOffsets: false,
                 },
                 commands: {
                     runCommands: true

--- a/source/lib/configuration/configuration.types.ts
+++ b/source/lib/configuration/configuration.types.ts
@@ -24,6 +24,7 @@ export type ConfigurationObject = {
             verifyPatch: boolean,
             backupFiles: boolean,
             skipWritingBinary: boolean,
+            use64BitOffsets: boolean,
         },
         commands: {
             runCommands: boolean

--- a/source/lib/patches/buffer.ts
+++ b/source/lib/patches/buffer.ts
@@ -134,6 +134,39 @@ export namespace BufferUtils {
     }
 
     /**
+     * Patch a buffer using a bigint offset
+     *
+     * @param params.buffer Buffer to patch
+     * @param params.offset BigInt offset
+     * @param params.previousValue Decimal previous value to find
+     * @param params.newValue Decimal new value to write
+     * @param params.options Patch options object
+     * @returns Patched buffer
+     */
+    export function patchBufferBigInt({
+        buffer,
+        offset,
+        previousValue,
+        newValue,
+        options
+    }:{
+        buffer: Buffer,
+        offset: bigint,
+        previousValue: number,
+        newValue: number,
+        options: OptionsType
+    }): Buffer {
+        const numericOffset: number = Number(offset);
+        return patchBuffer({
+            buffer,
+            offset: numericOffset,
+            previousValue,
+            newValue,
+            options
+        });
+    }
+
+    /**
      * Write a null value to a buffer
      * 
      * @param params.buffer Buffer to manipulate

--- a/source/lib/patches/patches.ts
+++ b/source/lib/patches/patches.ts
@@ -14,7 +14,7 @@ import Parser from './parser.js';
 const { parsePatchFile } = Parser;
 
 import Buffer from './buffer.js';
-const { patchBuffer } = Buffer;
+const { patchBuffer, patchBufferBigInt } = Buffer;
 
 import {
     ConfigurationObject,
@@ -142,20 +142,40 @@ export namespace Patches {
         { fileDataBuffer: Buffer, patchData: PatchArray, patchOptions: PatchOptionsObject }): Buffer {
 
         var buffer: Buffer = fileDataBuffer;
+        const { use64BitOffsets } = patchOptions;
         for (const patch of patchData) {
             const { offset, previousValue, newValue } = patch;
             const { forcePatch, unpatchMode, nullPatch, failOnUnexpectedPreviousValue, warnOnUnexpectedPreviousValue, skipWritePatch } = patchOptions;
-            buffer = patchBuffer({
-                buffer, offset, previousValue, newValue,
-                options: {
-                    forcePatch,
-                    unpatchMode,
-                    nullPatch,
-                    failOnUnexpectedPreviousValue,
-                    warnOnUnexpectedPreviousValue,
-                    skipWritePatch
-                }
-            });
+            if (use64BitOffsets === true)
+                buffer = patchBufferBigInt({
+                    buffer,
+                    offset: BigInt(offset),
+                    previousValue,
+                    newValue,
+                    options: {
+                        forcePatch,
+                        unpatchMode,
+                        nullPatch,
+                        failOnUnexpectedPreviousValue,
+                        warnOnUnexpectedPreviousValue,
+                        skipWritePatch
+                    }
+                });
+            else
+                buffer = patchBuffer({
+                    buffer,
+                    offset,
+                    previousValue,
+                    newValue,
+                    options: {
+                        forcePatch,
+                        unpatchMode,
+                        nullPatch,
+                        failOnUnexpectedPreviousValue,
+                        warnOnUnexpectedPreviousValue,
+                        skipWritePatch
+                    }
+                });
         }
         return buffer;
     }

--- a/test/patches.test.js
+++ b/test/patches.test.js
@@ -37,4 +37,24 @@ describe('Patches.runPatches', () => {
     const data = fs.readFileSync(testBinPath);
     expect(data[0]).toBe(0xff);
   });
+
+  test('patches using 64bit offsets flag', async () => {
+    const config = ConfigurationDefaults.getDefaultConfigurationObject();
+    config.patches = [
+      { name: 'test', patchFilename: 'test.patch', fileNamePath: testBinPath, enabled: true }
+    ];
+    const pOpts = config.options.patches;
+    pOpts.backupFiles = false;
+    pOpts.fileSizeCheck = false;
+    pOpts.skipWritingBinary = false;
+    pOpts.warnOnUnexpectedPreviousValue = false;
+    pOpts.failOnUnexpectedPreviousValue = false;
+    pOpts.runPatches = true;
+    pOpts.use64BitOffsets = true;
+
+    fs.writeFileSync(testBinPath, Buffer.from([0x00]));
+    await Patches.runPatches({ configuration: config });
+    const data = fs.readFileSync(testBinPath);
+    expect(data[0]).toBe(0xff);
+  });
 });


### PR DESCRIPTION
## Summary
- add `use64BitOffsets` option in config
- extend patch options types and defaults
- implement `patchBufferBigInt` helper
- select patching method based on `use64BitOffsets`
- test 64bit option in patches test

## Testing
- `npm run test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6861267225d883259645058759d91031