### PR TITLE
Implement offset validation

### DIFF
--- a/source/lib/configuration/configuration.defaults.ts
+++ b/source/lib/configuration/configuration.defaults.ts
@@ -39,6 +39,7 @@ export namespace ConfigurationDefaults {
                     fileSizeCheck: true,
                     fileSizeThreshold: 0,
                     skipWritePatch: false,
+                    allowOffsetOverflow: false,
                     failOnUnexpectedPreviousValue: false,
                     warnOnUnexpectedPreviousValue: true,
                     nullPatch: false,

--- a/source/lib/configuration/configuration.types.ts
+++ b/source/lib/configuration/configuration.types.ts
@@ -17,6 +17,8 @@ export type ConfigurationObject = {
             fileSizeCheck: boolean,
             fileSizeThreshold: number,
             skipWritePatch: boolean,
+            /** Allow patching offsets past the end of the file */
+            allowOffsetOverflow: boolean,
             failOnUnexpectedPreviousValue: boolean,
             warnOnUnexpectedPreviousValue: boolean,
             nullPatch: boolean,

--- a/source/lib/patches/buffer.types.ts
+++ b/source/lib/patches/buffer.types.ts
@@ -6,5 +6,7 @@ export type OptionsType = {
     nullPatch: boolean,
     failOnUnexpectedPreviousValue: boolean,
     warnOnUnexpectedPreviousValue: boolean,
-    skipWritePatch: boolean
+    skipWritePatch: boolean,
+    /** Allow patching offsets past the end of the file */
+    allowOffsetOverflow: boolean
 };

--- a/source/lib/patches/patches.ts
+++ b/source/lib/patches/patches.ts
@@ -2,7 +2,7 @@ import Debug from '../auxiliary/debug.js';
 const { log } = Debug;
 
 import colorsCli from 'colors-cli';
-const { red_bt, white } = colorsCli;
+const { red_bt, white, yellow_bt } = colorsCli;
 
 
 import { join } from 'path';
@@ -152,10 +152,15 @@ export namespace Patches {
         { fileDataBuffer: Buffer, patchData: PatchArray, patchOptions: PatchOptionsObject }): Buffer {
 
         var buffer: Buffer = fileDataBuffer;
+        const fileSize: number = buffer.length;
         for (const patch of patchData) {
             const { offset, previousValue, newValue } = patch;
             const offsetNumber: number = Number(offset);
-            const { forcePatch, unpatchMode, nullPatch, failOnUnexpectedPreviousValue, warnOnUnexpectedPreviousValue, skipWritePatch } = patchOptions;
+            const { forcePatch, unpatchMode, nullPatch, failOnUnexpectedPreviousValue, warnOnUnexpectedPreviousValue, skipWritePatch, allowOffsetOverflow } = patchOptions;
+            if (offsetNumber >= fileSize && allowOffsetOverflow !== true) {
+                log({ message: `Offset ${offset} exceeds file size ${fileSize}, skipping patch`, color: yellow_bt });
+                continue;
+            }
             buffer = patchBuffer({
                 buffer, offset: offsetNumber, previousValue, newValue,
                 options: {
@@ -164,7 +169,8 @@ export namespace Patches {
                     nullPatch,
                     failOnUnexpectedPreviousValue,
                     warnOnUnexpectedPreviousValue,
-                    skipWritePatch
+                    skipWritePatch,
+                    allowOffsetOverflow
                 }
             });
         }

--- a/test/patches.test.js
+++ b/test/patches.test.js
@@ -60,4 +60,24 @@ describe('Patches.runPatches', () => {
     const data = fs.readFileSync(testBinPath);
     expect(data[0]).toBe(0x00);
   });
+
+  test('out-of-range offsets do not enlarge file', async () => {
+    const config = ConfigurationDefaults.getDefaultConfigurationObject();
+    fs.writeFileSync(testBinPath, Buffer.from([0x00]));
+    config.patches = [
+      { name: 'big', patchFilename: 'big.patch', fileNamePath: testBinPath, enabled: true }
+    ];
+    const pOpts = config.options.patches;
+    pOpts.backupFiles = false;
+    pOpts.fileSizeCheck = false;
+    pOpts.skipWritingBinary = false;
+    pOpts.warnOnUnexpectedPreviousValue = false;
+    pOpts.failOnUnexpectedPreviousValue = false;
+    pOpts.allowOffsetOverflow = false;
+    pOpts.runPatches = true;
+
+    await Patches.runPatches({ configuration: config });
+    const stats = fs.statSync(testBinPath);
+    expect(stats.size).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary
- prevent patches from writing past EOF
- support `allowOffsetOverflow` patch option
- test out-of-range patch offsets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686130d631dc832597bb68c41a121132