### PR TITLE
Add Packer helper tests

### DIFF
--- a/test/packer.helpers.test.js
+++ b/test/packer.helpers.test.js
@@ -1,0 +1,32 @@
+import { Packer } from '../source/lib/filedrops/packer.ts';
+import { basename, extname } from 'path';
+
+describe('Packer helper functions', () => {
+  const paths = [
+    '/usr/local/bin/file.txt',
+    'C:\\Program Files\\app\\file.exe',
+    '/path/to/archive.tar.gz',
+    'C:\\path\\archive.tar.gz',
+    '/path/README',
+    'C:\\noext'
+  ];
+
+  test.each(paths)('getFilename returns basename for %s', (p) => {
+    expect(Packer.getFilename({ filePath: p })).toBe(basename(p));
+  });
+
+  test.each(paths)('getFilenameWithoutExtension returns name without ext for %s', (p) => {
+    const expected = basename(p, extname(p));
+    expect(Packer.getFilenameWithoutExtension({ filePath: p })).toBe(expected);
+  });
+
+  test.each(paths)('getPackedFilename appends .pack for %s', (p) => {
+    const expected = `${basename(p, extname(p))}.pack`;
+    expect(Packer.getPackedFilename({ filePath: p })).toBe(expected);
+  });
+
+  test.each(paths)('getPackedPath adds .pack extension to path for %s', (p) => {
+    const expected = `${p}.pack`;
+    expect(Packer.getPackedPath({ filePath: p })).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary
- cover helper functions in `Packer` with new tests
- test POSIX and Windows-style paths
- handle multiple dots and no extension cases

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861483c9a948325a954b5ce0ac862a5