### PR TITLE
Add Debug enable/disable tests

### DIFF
--- a/source/lib/auxiliary/debug.ts
+++ b/source/lib/auxiliary/debug.ts
@@ -57,6 +57,7 @@ export namespace Debug {
     export function disable(): boolean {
         try {
             setEnv({ envVarName: DEBUGGING, varValue: false });
+            setEnv({ envVarName: LOGGING, varValue: false });
             return true;
         } catch {
             return false;

--- a/test/debug.test.js
+++ b/test/debug.test.js
@@ -1,0 +1,40 @@
+import { jest } from '@jest/globals';
+import Debug from '../source/lib/auxiliary/debug.ts';
+import Constants from '../source/lib/configuration/constants.ts';
+
+const { DEBUGGING, LOGGING } = Constants;
+
+let originalDebugging;
+let originalLogging;
+
+beforeEach(() => {
+  originalDebugging = process.env[DEBUGGING];
+  originalLogging = process.env[LOGGING];
+  delete process.env[DEBUGGING];
+  delete process.env[LOGGING];
+});
+
+afterEach(() => {
+  if (originalDebugging === undefined) delete process.env[DEBUGGING];
+  else process.env[DEBUGGING] = originalDebugging;
+  if (originalLogging === undefined) delete process.env[LOGGING];
+  else process.env[LOGGING] = originalLogging;
+});
+
+describe('Debug.enable and disable', () => {
+  test('enable sets env vars and isEnabled true', () => {
+    Debug.enable({ logging: true });
+    expect(process.env[DEBUGGING]).toBe('true');
+    expect(process.env[LOGGING]).toBe('true');
+    expect(Debug.isEnabled()).toEqual({ DEBUGGING: true, LOGGING: true });
+  });
+
+  test('disable unsets env vars and isEnabled false', () => {
+    Debug.enable({ logging: true });
+    Debug.disable();
+    expect(process.env[DEBUGGING]).toBe('false');
+    const logVal = process.env[LOGGING];
+    expect(logVal === undefined || logVal === 'false').toBe(true);
+    expect(Debug.isEnabled()).toEqual({ DEBUGGING: false, LOGGING: false });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for Debug utilities
- ensure `Debug.disable` clears logging flag

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686150b8345883259024e164f3be1f67