### PR TITLE
Add runFunction error case test

### DIFF
--- a/test/composites.test.js
+++ b/test/composites.test.js
@@ -70,6 +70,12 @@ describe('Patcher.runFunction', () => {
     await Patcher.runFunction({ configuration: config, functionName: Constants.COMP_PATCHES });
     expect(Patches.default.runPatches).toHaveBeenCalledWith({ configuration: config });
   });
+
+  test('logs error when unknown function is provided', async () => {
+    const config = ConfigurationDefaults.getDefaultConfigurationObject();
+    await Patcher.runFunction({ configuration: config, functionName: 'bad' });
+    expect(Debug.default.log).toHaveBeenCalled();
+  });
 });
 
 describe('Patcher.runPatcher', () => {


### PR DESCRIPTION
## Summary
- mock runCommands, runFiledrops and runPatches in composites tests
- verify error logging if runFunction is called with an unknown name

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686150a7b3d08325a714a02c39be1fa5