### PR TITLE
Add tests for scheduler and services commands

### DIFF
--- a/test/commands.services.test.js
+++ b/test/commands.services.test.js
@@ -1,0 +1,123 @@
+import { jest } from '@jest/globals';
+import { ConfigurationDefaults } from '../source/lib/configuration/configuration.defaults.ts';
+
+async function loadModules(platform) {
+  jest.resetModules();
+  jest.clearAllMocks();
+
+  const windows = platform === 'win';
+  const mac = platform === 'mac';
+  const constants = {
+    COMM_TASKS_DELETE: 'delete',
+    COMM_TASKS_STOP: 'stop',
+    COMM_SERVICES_STOP: 'stop',
+    COMM_SERVICES_DISABLE: 'disable',
+    COMM_SERVICES_REMOVE: 'delete',
+    TASKSCHD_BIN: windows ? 'schtasks.exe' : mac ? 'launchctl' : 'systemctl',
+    SERVICE_BIN: windows ? 'sc.exe' : mac ? 'launchctl' : 'systemctl',
+    TASKKILL_BIN: windows ? 'taskkill.exe' : 'kill',
+    IS_WINDOWS: windows,
+    IS_MACOS: mac
+  };
+
+  jest.unstable_mockModule('../source/lib/configuration/constants.js', () => ({
+    default: constants
+  }));
+
+  jest.unstable_mockModule('../source/lib/commands/command.js', () => ({
+    default: { runCommand: jest.fn() }
+  }));
+
+  const mod = await import('../source/lib/commands/commands.services.js');
+  const Command = await import('../source/lib/commands/command.js');
+
+  return { CommandsServices: mod.CommandsServices, Command };
+}
+
+const removeAliases = ['remove', 'serviceRemove', 'svRemove', 'removeService', 'removeSv'];
+const stopAliases = ['stop', 'serviceStop', 'svStop', 'stopService', 'stopSv'];
+
+describe('CommandsServices parameter builders', () => {
+  test.each(removeAliases)('remove alias %s on Windows', async (fn) => {
+    const { CommandsServices, Command } = await loadModules('win');
+    Command.default.runCommand.mockResolvedValue('');
+    await CommandsServices[fn]({ serviceName: 'svc' });
+    expect(Command.default.runCommand).toHaveBeenLastCalledWith({
+      command: 'sc.exe',
+      parameters: 'delete svc'
+    });
+  });
+
+  test.each(removeAliases)('remove alias %s on macOS', async (fn) => {
+    const { CommandsServices, Command } = await loadModules('mac');
+    Command.default.runCommand.mockResolvedValue('');
+    await CommandsServices[fn]({ serviceName: 'svc' });
+    expect(Command.default.runCommand).toHaveBeenLastCalledWith({
+      command: 'launchctl',
+      parameters: 'remove svc'
+    });
+  });
+
+  test.each(removeAliases)('remove alias %s on Linux', async (fn) => {
+    const { CommandsServices, Command } = await loadModules('linux');
+    Command.default.runCommand.mockResolvedValue('');
+    await CommandsServices[fn]({ serviceName: 'svc' });
+    expect(Command.default.runCommand).toHaveBeenLastCalledWith({
+      command: 'systemctl',
+      parameters: 'disable --now svc'
+    });
+  });
+
+  test.each(stopAliases)('stop alias %s on Windows', async (fn) => {
+    const { CommandsServices, Command } = await loadModules('win');
+    Command.default.runCommand.mockResolvedValue('');
+    await CommandsServices[fn]({ serviceName: 'svc' });
+    expect(Command.default.runCommand).toHaveBeenLastCalledWith({
+      command: 'sc.exe',
+      parameters: 'stop svc'
+    });
+  });
+
+  test.each(stopAliases)('stop alias %s on macOS', async (fn) => {
+    const { CommandsServices, Command } = await loadModules('mac');
+    Command.default.runCommand.mockResolvedValue('');
+    await CommandsServices[fn]({ serviceName: 'svc' });
+    expect(Command.default.runCommand).toHaveBeenLastCalledWith({
+      command: 'launchctl',
+      parameters: 'stop svc'
+    });
+  });
+
+  test.each(stopAliases)('stop alias %s on Linux', async (fn) => {
+    const { CommandsServices, Command } = await loadModules('linux');
+    Command.default.runCommand.mockResolvedValue('');
+    await CommandsServices[fn]({ serviceName: 'svc' });
+    expect(Command.default.runCommand).toHaveBeenLastCalledWith({
+      command: 'systemctl',
+      parameters: 'stop svc'
+    });
+  });
+});
+
+describe('CommandsServices.runCommandsServices', () => {
+  test('runs enabled services only', async () => {
+    const { CommandsServices, Command } = await loadModules('win');
+    Command.default.runCommand.mockResolvedValue('');
+    const cfg = ConfigurationDefaults.getDefaultConfigurationObject();
+    cfg.commands.services = [
+      { name: 'svc1', command: 'stop', enabled: true },
+      { name: 'svc2', command: 'disable', enabled: true },
+      { name: 'svc3', command: 'delete', enabled: false }
+    ];
+    await CommandsServices.runCommandsServices({ configuration: cfg });
+    expect(Command.default.runCommand).toHaveBeenCalledTimes(2);
+    expect(Command.default.runCommand).toHaveBeenNthCalledWith(1, {
+      command: 'sc.exe',
+      parameters: 'stop svc1'
+    });
+    expect(Command.default.runCommand).toHaveBeenNthCalledWith(2, {
+      command: 'sc.exe',
+      parameters: 'config svc2 start= disabled'
+    });
+  });
+});

--- a/test/commands.taskschd.test.js
+++ b/test/commands.taskschd.test.js
@@ -1,0 +1,118 @@
+import { jest } from '@jest/globals';
+import { ConfigurationDefaults } from '../source/lib/configuration/configuration.defaults.ts';
+
+async function loadModules(platform) {
+  jest.resetModules();
+  jest.clearAllMocks();
+
+  const windows = platform === 'win';
+  const mac = platform === 'mac';
+  const constants = {
+    COMM_TASKS_DELETE: 'delete',
+    COMM_TASKS_STOP: 'stop',
+    COMM_SERVICES_STOP: 'stop',
+    COMM_SERVICES_DISABLE: 'disable',
+    COMM_SERVICES_REMOVE: 'delete',
+    TASKSCHD_BIN: windows ? 'schtasks.exe' : mac ? 'launchctl' : 'systemctl',
+    SERVICE_BIN: windows ? 'sc.exe' : mac ? 'launchctl' : 'systemctl',
+    TASKKILL_BIN: windows ? 'taskkill.exe' : 'kill',
+    IS_WINDOWS: windows,
+    IS_MACOS: mac
+  };
+
+  jest.unstable_mockModule('../source/lib/configuration/constants.js', () => ({
+    default: constants
+  }));
+
+  jest.unstable_mockModule('../source/lib/commands/command.js', () => ({
+    default: { runCommand: jest.fn() }
+  }));
+
+  const mod = await import('../source/lib/commands/commands.taskschd.js');
+  const Command = await import('../source/lib/commands/command.js');
+
+  return { CommandsTaskscheduler: mod.CommandsTaskscheduler, Command };
+}
+
+const removeAliases = ['remove', 'removeTask', 'rmTask', 'taskRemove', 'taskRm'];
+const stopAliases = ['stop', 'stopTask', 'taskStop'];
+
+describe('CommandsTaskscheduler parameter builders', () => {
+  test.each(removeAliases)('remove alias %s on Windows', async (fn) => {
+    const { CommandsTaskscheduler, Command } = await loadModules('win');
+    Command.default.runCommand.mockResolvedValue('');
+    await CommandsTaskscheduler[fn]({ taskName: 'task' });
+    expect(Command.default.runCommand).toHaveBeenLastCalledWith({
+      command: 'schtasks.exe',
+      parameters: '/delete /f /tn "task"'
+    });
+  });
+
+  test.each(removeAliases)('remove alias %s on macOS', async (fn) => {
+    const { CommandsTaskscheduler, Command } = await loadModules('mac');
+    Command.default.runCommand.mockResolvedValue('');
+    await CommandsTaskscheduler[fn]({ taskName: 'task' });
+    expect(Command.default.runCommand).toHaveBeenLastCalledWith({
+      command: 'launchctl',
+      parameters: 'remove task'
+    });
+  });
+
+  test.each(removeAliases)('remove alias %s on Linux', async (fn) => {
+    const { CommandsTaskscheduler, Command } = await loadModules('linux');
+    Command.default.runCommand.mockResolvedValue('');
+    await CommandsTaskscheduler[fn]({ taskName: 'task' });
+    expect(Command.default.runCommand).toHaveBeenLastCalledWith({
+      command: 'systemctl',
+      parameters: 'disable --now task'
+    });
+  });
+
+  test.each(stopAliases)('stop alias %s on Windows', async (fn) => {
+    const { CommandsTaskscheduler, Command } = await loadModules('win');
+    Command.default.runCommand.mockResolvedValue('');
+    await CommandsTaskscheduler[fn]({ taskName: 'task' });
+    expect(Command.default.runCommand).toHaveBeenLastCalledWith({
+      command: 'schtasks.exe',
+      parameters: '/end /tn "task"'
+    });
+  });
+
+  test.each(stopAliases)('stop alias %s on macOS', async (fn) => {
+    const { CommandsTaskscheduler, Command } = await loadModules('mac');
+    Command.default.runCommand.mockResolvedValue('');
+    await CommandsTaskscheduler[fn]({ taskName: 'task' });
+    expect(Command.default.runCommand).toHaveBeenLastCalledWith({
+      command: 'launchctl',
+      parameters: 'stop task'
+    });
+  });
+
+  test.each(stopAliases)('stop alias %s on Linux', async (fn) => {
+    const { CommandsTaskscheduler, Command } = await loadModules('linux');
+    Command.default.runCommand.mockResolvedValue('');
+    await CommandsTaskscheduler[fn]({ taskName: 'task' });
+    expect(Command.default.runCommand).toHaveBeenLastCalledWith({
+      command: 'systemctl',
+      parameters: 'stop task'
+    });
+  });
+});
+
+describe('CommandsTaskscheduler.runCommandsTaskScheduler', () => {
+  test('runs only enabled tasks', async () => {
+    const { CommandsTaskscheduler, Command } = await loadModules('win');
+    Command.default.runCommand.mockResolvedValue('');
+    const cfg = ConfigurationDefaults.getDefaultConfigurationObject();
+    cfg.commands.tasks = [
+      { name: 't1', command: 'delete', enabled: true },
+      { name: 't2', command: 'stop', enabled: false }
+    ];
+    await CommandsTaskscheduler.runCommandsTaskScheduler({ configuration: cfg });
+    expect(Command.default.runCommand).toHaveBeenCalledTimes(1);
+    expect(Command.default.runCommand).toHaveBeenCalledWith({
+      command: 'schtasks.exe',
+      parameters: '/delete /f /tn "t1"'
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add new unit tests for commands.taskschd and commands.services
- verify parameter construction for remove/stop aliases
- ensure only enabled entries run in scheduler/services command runners

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68615bf9ca148325bad19b09614e0550