### PR TITLE
Add large file threshold constant

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -271,7 +271,7 @@ use 16-digit hexadecimal offsets. For example:
 ```
 `patcherjs` automatically switches to 64‑bit mode when a
 patch includes an offset longer than eight hex digits or the
-target file is larger than 2&nbsp;GB.
+target file exceeds the `LARGE_FILE_THRESHOLD` (2&nbsp;GB).
 ```
 OFFSET: PREVIOUS_VALUE NEW_VALUE
 ```

--- a/source/lib/configuration/constants.ts
+++ b/source/lib/configuration/constants.ts
@@ -79,6 +79,8 @@ namespace Constants {
     export const PATCHES_BACKUPEXT: string = `.bak`;
     export const PATCHES_BASEPATH: string = join('patch_files', sep);
     export const PATCHES_BASEUNPACKEDPATH: string = join('patch_files_unpacked', sep);
+    /** Threshold for considering a file "large" when patching */
+    export const LARGE_FILE_THRESHOLD: number = 0x80000000;
 
 
     // COMMANDS TASKSCHEDULER

--- a/source/lib/patches/patches.ts
+++ b/source/lib/patches/patches.ts
@@ -28,7 +28,8 @@ import {
 
 import Constants from '../configuration/constants.js';
 const {
-    PATCHES_BASEPATH
+    PATCHES_BASEPATH,
+    LARGE_FILE_THRESHOLD
 } = Constants;
 
 export namespace Patches {
@@ -82,7 +83,7 @@ export namespace Patches {
 
             const fileSize: number = await getFileSizeUsingPath({ filePath });
             const hasBigOffset: boolean = patchData.some(p => p.offset > 0xffffffffn);
-            if (hasBigOffset || fileSize > 2147483648) {
+            if (hasBigOffset || fileSize > LARGE_FILE_THRESHOLD) {
                 if (patchOptions.skipWritingBinary === false)
                     await patchLargeFile({ filePath, patchData, options: patchOptions });
                 else


### PR DESCRIPTION
## Summary
- add `LARGE_FILE_THRESHOLD` constant
- use `LARGE_FILE_THRESHOLD` when patching large files
- document the threshold in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861844345388325ac649016814c3395