### PR TITLE
Handle offset checks in BufferUtils

### DIFF
--- a/source/lib/patches/buffer.ts
+++ b/source/lib/patches/buffer.ts
@@ -1,6 +1,3 @@
-import BufferWrappers from '../patches/buffer.wrappers.js';
-const { createBuffer } = BufferWrappers;
-
 import * as fs from 'fs/promises';
 
 import Debug from '../auxiliary/debug.js';
@@ -73,9 +70,14 @@ export namespace BufferUtils {
             failOnUnexpectedPreviousValue,
             warnOnUnexpectedPreviousValue,
             skipWritePatch,
+            allowOffsetOverflow,
             bigEndian = false
         } = options;
         try {
+            if (allowOffsetOverflow !== true && offset + byteLength > buffer.length) {
+                log({ message: `Offset ${offset} with length ${byteLength} exceeds buffer size ${buffer.length}, skipping patch`, color: yellow_bt });
+                return buffer;
+            }
             let currentValue: number | bigint;
             switch (byteLength) {
                 case 1:
@@ -152,8 +154,7 @@ export namespace BufferUtils {
             return buffer;
         } catch (error: any) {
             log({ message: `An error has occurred: ${error}`, color: red_bt });
-            const errorBufferSize: number = 0;
-            return createBuffer({ size: errorBufferSize });
+            throw error;
         }
     }
 
@@ -189,8 +190,8 @@ export namespace BufferUtils {
                 if (offset > maxSafe)
                     throw new Error(`Offset ${offset} exceeds Number.MAX_SAFE_INTEGER`);
                 const position = Number(offset);
-                if (position >= fileSize && allowOffsetOverflow !== true) {
-                    log({ message: `Offset ${offset} exceeds file size ${fileSize}, skipping patch`, color: yellow_bt });
+                if (position + byteLength > fileSize && allowOffsetOverflow !== true) {
+                    log({ message: `Offset ${offset} with length ${byteLength} exceeds file size ${fileSize}, skipping patch`, color: yellow_bt });
                     continue;
                 }
                 const buf = Buffer.alloc(byteLength);


### PR DESCRIPTION
## Summary
- validate offsets against buffer length in `patchBuffer`
- skip writes that exceed file size in `patchLargeFile`
- keep the original error when patching fails
- test out-of-range offsets for buffers and files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861874af65483258baf0f842d5ed03c