### PR TITLE
Fix buffer utilities import

### DIFF
--- a/source/lib/patches/patches.ts
+++ b/source/lib/patches/patches.ts
@@ -13,8 +13,8 @@ const { backupFile, getFileSizeUsingPath, readBinaryFile, readPatchFile, writeBi
 import Parser from './parser.js';
 const { parsePatchFile } = Parser;
 
-import Buffer from './buffer.js';
-const { patchBuffer, patchLargeFile } = Buffer;
+import BufferUtils from './buffer.js';
+const { patchBuffer, patchLargeFile } = BufferUtils;
 
 import {
     ConfigurationObject,


### PR DESCRIPTION
## Summary
- update buffer import to `BufferUtils`

## Testing
- `npm test` *(fails: Cannot find type definition file for 'node')*
- `npm run lint` *(fails: ESLint couldn't find the plugin)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6861ac4cbae0832583d21f39846ab601