### PR TITLE
Fix fs open import

### DIFF
--- a/source/lib/auxiliary/file.ts
+++ b/source/lib/auxiliary/file.ts
@@ -1,5 +1,4 @@
 import * as fs from 'fs/promises';
-import { open } from 'fs/promises';
 
 import BufferWrappers from '../patches/buffer.wrappers.js';
 const { createBuffer } = BufferWrappers;
@@ -44,7 +43,7 @@ export namespace File {
             const cantReadFile: boolean = !(await isFileReadable({ filePath }));
             if (cantReadFile)
                 throw new Error(`File is not readable, is missing or corrupted`);
-            const fileHandle: FileHandle = await open(filePath);
+            const fileHandle: FileHandle = await fs.open(filePath);
             const bufferSize: number = await getFileSize({ fileHandle });
             if (bufferSize === 0)
                 log({ message: 'File size is 0, file may be corrupted or invalid', color: yellow_bt });
@@ -85,7 +84,7 @@ export namespace File {
             log({ message: `Opening file path, ${filePath}, in read mode`, color: white });
             if (!(await isFileReadable({ filePath })))
                 throw new Error(`File is not readable, is missing or corrupted`);
-            const fileHandle: FileHandle = await open(filePath);
+            const fileHandle: FileHandle = await fs.open(filePath);
             log({ message: 'Getting file size', color: white });
             const bufferSize: number = await getFileSize({ fileHandle });
             if (bufferSize === 0)


### PR DESCRIPTION
## Summary
- update `File` utility to use `fs.open`
- remove unused `open` import

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6861df9a1180832591bc194bb14dd7f1