### PR TITLE
Fix filePath check in encryption

### DIFF
--- a/source/lib/filedrops/crypt.ts
+++ b/source/lib/filedrops/crypt.ts
@@ -60,7 +60,7 @@ export namespace Encryption {
         try {
             var fileData: Buffer | string;
 
-            if (filePath && typeof filePath !== undefined && typeof filePath === 'string') {
+            if (filePath && filePath !== undefined && typeof filePath === 'string') {
                 const filename: string = getFilename({ filePath });
                 log({ message: `Reading file to encrypt ${filename}`, color: white });
                 fileData = await readBinaryFile({ filePath });
@@ -138,7 +138,7 @@ export namespace Encryption {
         try {
             var fileData: Buffer;
 
-            if (filePath && typeof filePath !== undefined && typeof filePath === 'string') {
+            if (filePath && filePath !== undefined && typeof filePath === 'string') {
                 const filename: string = getFilename({ filePath });
                 log({ message: `Reading file to decrypt ${filename}`, color: white });
                 fileData = await readBinaryFile({ filePath });

--- a/test/crypt.test.js
+++ b/test/crypt.test.js
@@ -33,4 +33,10 @@ describe('Encryption.encryptFile and decryptFile', () => {
     await Crypt.encryptFile({ filePath: 'a.bin', key });
     expect(File.default.readBinaryFile).toHaveBeenCalledWith({ filePath: 'a.bin' });
   });
+
+  test('uses file input when decrypting', async () => {
+    const key = 'pw';
+    await Crypt.decryptFile({ filePath: 'b.bin', key });
+    expect(File.default.readBinaryFile).toHaveBeenCalledWith({ filePath: 'b.bin' });
+  });
 });


### PR DESCRIPTION
## Summary
- check for undefined directly in `encryptFile` and `decryptFile`
- extend encryption tests for decrypt file path usage

## Testing
- `npm test` *(fails: TypeScript errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68685a68bd2883259fbd5ab28a10f841