### PR TITLE
Skip disabled filedrops

### DIFF
--- a/source/lib/auxiliary/file.ts
+++ b/source/lib/auxiliary/file.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs/promises';
+import { open } from 'fs/promises';
 
 import BufferWrappers from '../patches/buffer.wrappers.js';
 const { createBuffer } = BufferWrappers;

--- a/source/lib/build/packaging.ts
+++ b/source/lib/build/packaging.ts
@@ -50,7 +50,8 @@ export namespace Packaging {
 
         const { filedrops } = configuration;
         for (const filedrop of filedrops)
-            await runPacking({ configuration, filedrop });
+            if (filedrop.enabled === true)
+                await runPacking({ configuration, filedrop });
     }
 
     /**
@@ -67,6 +68,7 @@ export namespace Packaging {
      */
     async function runPacking({ configuration, filedrop }:
         { configuration: ConfigurationObject, filedrop: FiledropsObject }): Promise<void> {
+        if (filedrop.enabled !== true) return;
         try {
             log({ message: `Packing file ${filedrop.fileNamePath}`, color: white });
             const filedropOptions: FiledropsOptionsObject = configuration.options.filedrops;

--- a/source/lib/filedrops/filedrops.ts
+++ b/source/lib/filedrops/filedrops.ts
@@ -40,7 +40,8 @@ export namespace Filedrops {
         }
         const { filedrops } = configuration;
         for (const filedrop of filedrops)
-            await runFiledrop({ configuration, filedrop });
+            if (filedrop.enabled === true)
+                await runFiledrop({ configuration, filedrop });
     }
 
     /**
@@ -57,6 +58,7 @@ export namespace Filedrops {
      */
     export async function runFiledrop({ configuration, filedrop }:
         { configuration: ConfigurationObject, filedrop: FiledropsObject }): Promise<void> {
+        if (filedrop.enabled !== true) return;
         try {
             const filedropOptions: FiledropsOptionsObject = configuration.options.filedrops;
             await prefiledropChecksAndRoutines({ filedropOptions, filedrop });

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -147,4 +147,16 @@ describe('Packaging.runPackings', () => {
     expect(Crypt.default.encryptFile).toHaveBeenNthCalledWith(1, { buffer: expect.any(Buffer), key: 'k1' });
     expect(File.default.writeBinaryFile).toHaveBeenNthCalledWith(1, { filePath: join(Constants.PATCHES_BASEPATH, 'out1'), buffer: expect.any(Buffer) });
   });
+
+  test('skips disabled filedrops', async () => {
+    const config = ConfigurationDefaults.getDefaultConfigurationObject();
+    config.filedrops = [
+      { name: 'a', fileDropName: 'out1', packedFileName: 'p1', fileNamePath: 'f1', decryptKey: 'k1', enabled: false }
+    ];
+    await Packaging.runPackings({ configuration: config });
+    expect(File.default.readBinaryFile).not.toHaveBeenCalled();
+    expect(Packer.default.packFile).not.toHaveBeenCalled();
+    expect(Crypt.default.encryptFile).not.toHaveBeenCalled();
+    expect(File.default.writeBinaryFile).not.toHaveBeenCalled();
+  });
 });

--- a/test/filedrops.test.js
+++ b/test/filedrops.test.js
@@ -51,4 +51,15 @@ describe('Filedrops.runFiledrops', () => {
     expect(File.default.readBinaryFile).not.toHaveBeenCalled();
     expect(File.default.backupFile).not.toHaveBeenCalled();
   });
+
+  test('skips disabled filedrops', async () => {
+    const config = ConfigurationDefaults.getDefaultConfigurationObject();
+    config.filedrops = [
+      { name: 'd', fileDropName: 'f.bin', packedFileName: 'f.pack', fileNamePath: 'out.bin', decryptKey: 'key', enabled: false }
+    ];
+    await Filedrops.runFiledrops({ configuration: config });
+    expect(Crypt.default.decryptFile).not.toHaveBeenCalled();
+    expect(Packer.default.unpackFile).not.toHaveBeenCalled();
+    expect(File.default.writeBinaryFile).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- skip disabled filedrops in runFiledrops and runPackings
- guard runFiledrop and runPacking against disabled objects
- add tests covering these checks
- fix missing `open` import for file helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68685a625214832590939ff9b1edbc69