### PR TITLE
fix checks in crypt.ts

### DIFF
--- a/source/lib/filedrops/crypt.ts
+++ b/source/lib/filedrops/crypt.ts
@@ -60,13 +60,13 @@ export namespace Encryption {
         try {
             var fileData: Buffer | string;
 
-            if (filePath && filePath !== undefined && typeof filePath === 'string') {
+            if (filePath && typeof filePath !== 'undefined' && typeof filePath === 'string') {
                 const filename: string = getFilename({ filePath });
                 log({ message: `Reading file to encrypt ${filename}`, color: white });
                 fileData = await readBinaryFile({ filePath });
             } else {
                 log({ message: `Reading buffer to encrypt`, color: white });
-                if (buffer && typeof buffer !== undefined && Buffer.isBuffer(buffer) === true) {
+                if (buffer && typeof buffer !== 'undefined' && Buffer.isBuffer(buffer) === true) {
                     fileData = buffer;
                 } else {
                     fileData = createBuffer({ size: 0 });
@@ -138,13 +138,13 @@ export namespace Encryption {
         try {
             var fileData: Buffer;
 
-            if (filePath && filePath !== undefined && typeof filePath === 'string') {
+            if (filePath && typeof filePath !== 'undefined' && typeof filePath === 'string') {
                 const filename: string = getFilename({ filePath });
                 log({ message: `Reading file to decrypt ${filename}`, color: white });
                 fileData = await readBinaryFile({ filePath });
             } else {
                 log({ message: `Reading buffer to decrypt`, color: white });
-                if (buffer && typeof buffer !== undefined && Buffer.isBuffer(buffer) === true) {
+                if (buffer && typeof buffer !== 'undefined' && Buffer.isBuffer(buffer) === true) {
                     fileData = buffer;
                 } else {
                     fileData = createBuffer({ size: 0 });


### PR DESCRIPTION
## Summary
- ensure filePath checks use `typeof !== 'undefined'`
- ensure buffer checks use `typeof !== 'undefined'`

## Testing
- `npm test` *(fails: TS2322/TS18048 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68685c1e4f0c8325a2b08c45a35ffcaf