### PR TITLE
Add disabled item tests

### DIFF
--- a/source/lib/auxiliary/file.ts
+++ b/source/lib/auxiliary/file.ts
@@ -44,7 +44,7 @@ export namespace File {
             const cantReadFile: boolean = !(await isFileReadable({ filePath }));
             if (cantReadFile)
                 throw new Error(`File is not readable, is missing or corrupted`);
-            fileHandle = await open(filePath);
+            fileHandle = await fs.open(filePath);
             const bufferSize: number = await getFileSize({ fileHandle });
             if (bufferSize === 0)
                 log({ message: 'File size is 0, file may be corrupted or invalid', color: yellow_bt });
@@ -89,7 +89,7 @@ export namespace File {
             log({ message: `Opening file path, ${filePath}, in read mode`, color: white });
             if (!(await isFileReadable({ filePath })))
                 throw new Error(`File is not readable, is missing or corrupted`);
-            fileHandle = await open(filePath);
+            fileHandle = await fs.open(filePath);
             log({ message: 'Getting file size', color: white });
             const bufferSize: number = await getFileSize({ fileHandle });
             if (bufferSize === 0)

--- a/source/lib/filedrops/filedrops.ts
+++ b/source/lib/filedrops/filedrops.ts
@@ -40,7 +40,8 @@ export namespace Filedrops {
         }
         const { filedrops } = configuration;
         for (const filedrop of filedrops)
-            await runFiledrop({ configuration, filedrop });
+            if (filedrop.enabled)
+                await runFiledrop({ configuration, filedrop });
     }
 
     /**

--- a/source/lib/patches/patches.ts
+++ b/source/lib/patches/patches.ts
@@ -54,7 +54,8 @@ export namespace Patches {
 
         const { patches } = configuration;
         for (const patch of patches)
-            await runPatch({ configuration, patch });
+            if (patch.enabled)
+                await runPatch({ configuration, patch });
     }
 
     /**

--- a/test/filedrops.test.js
+++ b/test/filedrops.test.js
@@ -51,4 +51,22 @@ describe('Filedrops.runFiledrops', () => {
     expect(File.default.readBinaryFile).not.toHaveBeenCalled();
     expect(File.default.backupFile).not.toHaveBeenCalled();
   });
+
+  test('disabled filedrops are skipped', async () => {
+    const config = ConfigurationDefaults.getDefaultConfigurationObject();
+    config.filedrops = [
+      { name: 'd', fileDropName: 'f.bin', packedFileName: 'f.pack', fileNamePath: 'out.bin', decryptKey: 'key', enabled: false }
+    ];
+    const opts = config.options.filedrops;
+    opts.runFiledrops = true;
+    opts.isFiledropPacked = true;
+    opts.isFiledropCrypted = true;
+    opts.backupFiles = false;
+    await Filedrops.runFiledrops({ configuration: config });
+    expect(Crypt.default.decryptFile).not.toHaveBeenCalled();
+    expect(Packer.default.unpackFile).not.toHaveBeenCalled();
+    expect(File.default.writeBinaryFile).not.toHaveBeenCalled();
+    expect(File.default.readBinaryFile).not.toHaveBeenCalled();
+    expect(File.default.backupFile).not.toHaveBeenCalled();
+  });
 });

--- a/test/patches.test.js
+++ b/test/patches.test.js
@@ -154,4 +154,23 @@ describe('Patches.runPatches', () => {
     const data = fs.readFileSync(testBinPath);
     expect(Array.from(data)).toEqual([0x00, 0x01]);
   });
+
+  test('disabled patches are skipped', async () => {
+    const config = ConfigurationDefaults.getDefaultConfigurationObject();
+    fs.writeFileSync(testBinPath, Buffer.from([0x00]));
+    config.patches = [
+      { name: 'test', patchFilename: 'test.patch', fileNamePath: testBinPath, enabled: false }
+    ];
+    const pOpts = config.options.patches;
+    pOpts.backupFiles = false;
+    pOpts.fileSizeCheck = false;
+    pOpts.skipWritingBinary = false;
+    pOpts.warnOnUnexpectedPreviousValue = false;
+    pOpts.failOnUnexpectedPreviousValue = false;
+    pOpts.runPatches = true;
+
+    await Patches.runPatches({ configuration: config });
+    const data = fs.readFileSync(testBinPath);
+    expect(data[0]).toBe(0x00);
+  });
 });


### PR DESCRIPTION
## Summary
- fix missing fs.open usage
- skip patches and filedrops when disabled
- add regression tests for disabled patches and filedrops

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68685c39e3ac8325820a6e5e42a8b152