### PR TITLE
Add empty folder handling to firstFilenameInFolder

### DIFF
--- a/source/lib/auxiliary/file.wrappers.ts
+++ b/source/lib/auxiliary/file.wrappers.ts
@@ -207,6 +207,10 @@ export namespace FileWrappers {
         return new Promise(function (resolve, reject) {
             readdir(folderPath)
                 .then(function (filenames) {
+                    if (filenames.length === 0) {
+                        reject(new Error('No files found in directory'));
+                        return;
+                    }
                     const completeFilePath: string = join(folderPath, filenames[0]);
                     resolve(completeFilePath);
                 }).catch(function (error) {

--- a/test/file.util.test.js
+++ b/test/file.util.test.js
@@ -62,6 +62,12 @@ describe('File utilities', () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  test('firstFilenameInFolder rejects when directory is empty', async () => {
+    const dir = fs.mkdtempSync(join(os.tmpdir(), 'fileutil-'));
+    await expect(File.firstFilenameInFolder({ folderPath: dir })).rejects.toThrow();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   test('firstFilenameInFolder rejects on failure', async () => {
     await expect(File.firstFilenameInFolder({ folderPath: '/missing' })).rejects.toThrow();
   });


### PR DESCRIPTION
## Summary
- reject when `firstFilenameInFolder` sees an empty directory
- test empty directory behaviour for `firstFilenameInFolder`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a6f4f6bc48325bb7a1510cfdf62bb