### PR TITLE
Fix parser trailing newline handling

### DIFF
--- a/source/lib/patches/parser.ts
+++ b/source/lib/patches/parser.ts
@@ -34,7 +34,9 @@ export namespace Parser {
             if (dataLength === 0)
                 throw new Error(`Patch file data is empty or corrupted`);
             log({ message: `Splitting file lines`, color: white });
-            const patchData: Array<any> = splitLines({ fileData });
+            let patchData: Array<any> = splitLines({ fileData });
+            // remove empty lines that may appear due to trailing newlines
+            patchData = patchData.filter((line) => line.trim().length > 0);
             log({ message: `Building patch objects array`, color: white });
             const patches: Array<any> = buildPatchesArray({ patchData });
             const patchesCount: number = patches.length;
@@ -65,7 +67,10 @@ export namespace Parser {
             var patches: PatchArray = [];
             log({ message: `Pushing patch objects into an array`, color: white });
             for (const [index, patchLine] of patchData.entries()) {
-                const patchObject: PatchObject = getPatchObject({ patchLine, index })
+                const trimmed = patchLine.trim();
+                if (trimmed.length === 0)
+                    continue;
+                const patchObject: PatchObject = getPatchObject({ patchLine: trimmed, index })
                 patches.push(patchObject);
             }
             const patchesPushed: number = patches.length;

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -30,4 +30,12 @@ describe('Parser.parsePatchFile', () => {
       { offset: 0x6n, previousValue: 0x0000000000000005n, newValue: 0x0000000000000006n, byteLength: 8 }
     ]);
   });
+
+  test('trailing newline does not produce extra patch', async () => {
+    const data = '00000000: 00 01\n';
+    const patches = await Parser.parsePatchFile({ fileData: data });
+    expect(patches).toEqual([
+      { offset: 0x00000000n, previousValue: 0x00, newValue: 0x01, byteLength: 1 }
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- remove blank lines when parsing patches
- ignore empty lines when building patch objects
- test that trailing newlines don't create empty patch entries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a784c8cac832590abec43cac82d7b