### PR TITLE
Replace exec with spawn using array args

### DIFF
--- a/source/lib/build/builder.ts
+++ b/source/lib/build/builder.ts
@@ -26,20 +26,20 @@ export namespace Builder {
 
         debug.log({ message: `Creating blob`, color: white });
         const nodeBin: string = `node`;
-        const blobParameters: string = `--experimental-sea-config sea-config.json`;
+        const blobParameters: string[] = ['--experimental-sea-config', 'sea-config.json'];
         await runCommand({ command: nodeBin, parameters: blobParameters });
 
         debug.log({ message: `Copying node binary`, color: white });
         const binaryName: string = process.platform === 'win32'
             ? `./sea/predist/patcherjs.exe`
             : `./sea/predist/patcherjs`;
-        const nodeCopyParameters: string = `-e "require('fs').copyFileSync(process.execPath, '${binaryName}')"`;
+        const nodeCopyParameters: string[] = ['-e', `require('fs').copyFileSync(process.execPath, '${binaryName}')`];
         await runCommand({ command: nodeBin, parameters: nodeCopyParameters });
 
         if (process.platform === 'win32') {
             debug.log({ message: `Removing signature`, color: white });
             const signtoolBin: string = `signtool`;
-            const signtoolUnsigningParameters: string = `remove /s ${binaryName}`;
+            const signtoolUnsigningParameters: string[] = ['remove', '/s', binaryName];
             await runCommand({ command: signtoolBin, parameters: signtoolUnsigningParameters });
         } else {
             debug.log({ message: `Skipping signature removal step on non-Windows platform`, color: white });
@@ -48,9 +48,14 @@ export namespace Builder {
         debug.log({ message: `Injecting script`, color: white });
         const npxBin: string = `npx`;
         const fuseRandomBytes: string = `fce680ab2cc467b6e072b8b5df1996b2` //randomBytes(16).toString(`hex`);
-        const injectionParameters1: string = `postject ${binaryName} NODE_SEA_BLOB ./sea/sea-prep.blob`;
-        const injectionParameters2: string = `--sentinel-fuse NODE_SEA_FUSE_${fuseRandomBytes}`;
-        const injectionParameters: string = `${injectionParameters1} ${injectionParameters2}`;
+        const injectionParameters: string[] = [
+            'postject',
+            binaryName,
+            'NODE_SEA_BLOB',
+            './sea/sea-prep.blob',
+            '--sentinel-fuse',
+            `NODE_SEA_FUSE_${fuseRandomBytes}`
+        ];
         await runCommand({ command: npxBin, parameters: injectionParameters });
 
         debug.log({ message: `Built unsigned node sea binary`, color: green_bt });

--- a/source/lib/commands/command.ts
+++ b/source/lib/commands/command.ts
@@ -1,4 +1,4 @@
-import { exec } from 'child_process';
+import { spawn } from 'child_process';
 
 import Debug from '../auxiliary/debug.js';
 const { log } = Debug;
@@ -20,7 +20,7 @@ export namespace Command {
      * @since 0.0.1
      */
     export async function runCommand({ command, parameters }:
-        { command: string, parameters: string }): Promise<string | null> {
+        { command: string, parameters: string[] }): Promise<string | null> {
         try {
             const result: string = await runCommandPromise({ command, parameters });
             return result;
@@ -47,11 +47,10 @@ export namespace Command {
      * @since 0.0.1
      */
     export async function runCommandPromise({ command, parameters }:
-        { command: string, parameters: string }): Promise<string> {
+        { command: string, parameters: string[] }): Promise<string> {
 
         return new Promise(function (resolve, reject) {
-            const fullCommand: string = `${command} ${parameters}`;
-            const childProcess: any = exec(fullCommand);
+            const childProcess: any = spawn(command, parameters, { shell: true });
             let output: string = '';
             childProcess.stdout.on('data', function (data) {
                 output += data.toString();

--- a/source/lib/commands/commands.kill.ts
+++ b/source/lib/commands/commands.kill.ts
@@ -80,9 +80,9 @@ export namespace CommandsKill {
         { taskName: string }): Promise<string | null> {
 
         const command: string = TASKKILL_BIN;
-        const parameters: string = IS_WINDOWS
-            ? `/f /im \"${taskName}\"`
-            : `-9 $(pgrep -f \"${taskName}\")`;
+        const parameters: string[] = IS_WINDOWS
+            ? ['/f', '/im', taskName]
+            : ['-9', `$(pgrep -f \"${taskName}\")`];
         const result: string | null = await runCommand({ command, parameters });
         return result;
     }

--- a/source/lib/commands/commands.services.ts
+++ b/source/lib/commands/commands.services.ts
@@ -108,9 +108,9 @@ export namespace CommandsServices {
         { serviceName: string }): Promise<string | null> {
 
         const command: string = SERVICE_BIN;
-        const parameters: string = IS_WINDOWS
-            ? `stop ${serviceName}`
-            : `stop ${serviceName}`;
+        const parameters: string[] = IS_WINDOWS
+            ? ['stop', serviceName]
+            : ['stop', serviceName];
         const result: string | null = await runCommand({ command, parameters });
         return result;
     }
@@ -134,9 +134,9 @@ export namespace CommandsServices {
         { serviceName: string }): Promise<string | null> {
 
         const command: string = SERVICE_BIN;
-        const parameters: string = IS_WINDOWS
-            ? `config ${serviceName} start= disabled`
-            : `disable ${serviceName}`;
+        const parameters: string[] = IS_WINDOWS
+            ? ['config', serviceName, 'start=', 'disabled']
+            : ['disable', serviceName];
         const result: string | null = await runCommand({ command, parameters });
         return result;
     }
@@ -161,11 +161,11 @@ export namespace CommandsServices {
         { serviceName: string }): Promise<string | null> {
 
         const command: string = SERVICE_BIN;
-        const parameters: string = IS_WINDOWS
-            ? `delete ${serviceName}`
+        const parameters: string[] = IS_WINDOWS
+            ? ['delete', serviceName]
             : IS_MACOS
-                ? `remove ${serviceName}`
-                : `disable --now ${serviceName}`;
+                ? ['remove', serviceName]
+                : ['disable', '--now', serviceName];
         const result: string | null = await runCommand({ command, parameters });
         return result;
     }

--- a/source/lib/commands/commands.taskschd.ts
+++ b/source/lib/commands/commands.taskschd.ts
@@ -91,11 +91,11 @@ export namespace CommandsTaskscheduler {
     export async function remove({ taskName }:
         { taskName: string }): Promise<string | null> {
         const command: string = TASKSCHD_BIN;
-        const parameters: string = IS_WINDOWS
-            ? `/delete /f /tn \"${taskName}\"`
+        const parameters: string[] = IS_WINDOWS
+            ? ['/delete', '/f', '/tn', taskName]
             : IS_MACOS
-                ? `remove ${taskName}`
-                : `disable --now ${taskName}`;
+                ? ['remove', taskName]
+                : ['disable', '--now', taskName];
         const result: string | null = await runCommand({ command, parameters });
         return result;
     }
@@ -118,9 +118,9 @@ export namespace CommandsTaskscheduler {
     export async function stop({ taskName }:
         { taskName: string }): Promise<string | null> {
         const command: string = TASKSCHD_BIN;
-        const parameters: string = IS_WINDOWS
-            ? `/end /tn \"${taskName}\"`
-            : `stop ${taskName}`;
+        const parameters: string[] = IS_WINDOWS
+            ? ['/end', '/tn', taskName]
+            : ['stop', taskName];
         const result: string | null = await runCommand({ command, parameters });
         return result;
     }

--- a/source/lib/commands/commands.ts
+++ b/source/lib/commands/commands.ts
@@ -113,7 +113,7 @@ export namespace Commands {
         for (const command of commands)
             if (command.enabled === true) {
                 log({ message: `Running general command ${command.name}: ${command.command}`, color: white });
-                await runCommand({ command: command.command, parameters: '' });
+                await runCommand({ command: command.command, parameters: [] });
             }
     }
 }

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -75,19 +75,26 @@ describe('Builder.buildExecutable', () => {
 
     expect(Command.default.runCommand).toHaveBeenNthCalledWith(1, {
       command: 'node',
-      parameters: '--experimental-sea-config sea-config.json'
+      parameters: ['--experimental-sea-config', 'sea-config.json']
     });
     expect(Command.default.runCommand).toHaveBeenNthCalledWith(2, {
       command: 'node',
-      parameters: "-e \"require('fs').copyFileSync(process.execPath, './sea/predist/patcherjs.exe')\""
+      parameters: ['-e', "require('fs').copyFileSync(process.execPath, './sea/predist/patcherjs.exe')"]
     });
     expect(Command.default.runCommand).toHaveBeenNthCalledWith(3, {
       command: 'signtool',
-      parameters: 'remove /s ./sea/predist/patcherjs.exe'
+      parameters: ['remove', '/s', './sea/predist/patcherjs.exe']
     });
     expect(Command.default.runCommand).toHaveBeenNthCalledWith(4, {
       command: 'npx',
-      parameters: 'postject ./sea/predist/patcherjs.exe NODE_SEA_BLOB ./sea/sea-prep.blob --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2'
+      parameters: [
+        'postject',
+        './sea/predist/patcherjs.exe',
+        'NODE_SEA_BLOB',
+        './sea/sea-prep.blob',
+        '--sentinel-fuse',
+        'NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2'
+      ]
     });
   });
 });

--- a/test/command.helpers.test.js
+++ b/test/command.helpers.test.js
@@ -43,12 +43,12 @@ describe('Command helpers - parameters', () => {
     await CommandsTaskscheduler.remove({ taskName: 'task' });
     expect(Command.default.runCommand).toHaveBeenLastCalledWith({
       command: 'schtasks.exe',
-      parameters: '/delete /f /tn "task"'
+      parameters: ['/delete', '/f', '/tn', 'task']
     });
     await CommandsTaskscheduler.stop({ taskName: 'task' });
     expect(Command.default.runCommand).toHaveBeenLastCalledWith({
       command: 'schtasks.exe',
-      parameters: '/end /tn "task"'
+      parameters: ['/end', '/tn', 'task']
     });
   });
 
@@ -58,12 +58,12 @@ describe('Command helpers - parameters', () => {
     await CommandsTaskscheduler.remove({ taskName: 'task' });
     expect(Command.default.runCommand).toHaveBeenLastCalledWith({
       command: 'launchctl',
-      parameters: 'remove task'
+      parameters: ['remove', 'task']
     });
     await CommandsTaskscheduler.stop({ taskName: 'task' });
     expect(Command.default.runCommand).toHaveBeenLastCalledWith({
       command: 'launchctl',
-      parameters: 'stop task'
+      parameters: ['stop', 'task']
     });
   });
 
@@ -73,12 +73,12 @@ describe('Command helpers - parameters', () => {
     await CommandsTaskscheduler.remove({ taskName: 'task' });
     expect(Command.default.runCommand).toHaveBeenLastCalledWith({
       command: 'systemctl',
-      parameters: 'disable --now task'
+      parameters: ['disable', '--now', 'task']
     });
     await CommandsTaskscheduler.stop({ taskName: 'task' });
     expect(Command.default.runCommand).toHaveBeenLastCalledWith({
       command: 'systemctl',
-      parameters: 'stop task'
+      parameters: ['stop', 'task']
     });
   });
 
@@ -88,17 +88,17 @@ describe('Command helpers - parameters', () => {
     await CommandsServices.stop({ serviceName: 'svc' });
     expect(Command.default.runCommand).toHaveBeenLastCalledWith({
       command: 'sc.exe',
-      parameters: 'stop svc'
+      parameters: ['stop', 'svc']
     });
     await CommandsServices.disable({ serviceName: 'svc' });
     expect(Command.default.runCommand).toHaveBeenLastCalledWith({
       command: 'sc.exe',
-      parameters: 'config svc start= disabled'
+      parameters: ['config', 'svc', 'start=', 'disabled']
     });
     await CommandsServices.remove({ serviceName: 'svc' });
     expect(Command.default.runCommand).toHaveBeenLastCalledWith({
       command: 'sc.exe',
-      parameters: 'delete svc'
+      parameters: ['delete', 'svc']
     });
   });
 
@@ -108,17 +108,17 @@ describe('Command helpers - parameters', () => {
     await CommandsServices.stop({ serviceName: 'svc' });
     expect(Command.default.runCommand).toHaveBeenLastCalledWith({
       command: 'launchctl',
-      parameters: 'stop svc'
+      parameters: ['stop', 'svc']
     });
     await CommandsServices.disable({ serviceName: 'svc' });
     expect(Command.default.runCommand).toHaveBeenLastCalledWith({
       command: 'launchctl',
-      parameters: 'disable svc'
+      parameters: ['disable', 'svc']
     });
     await CommandsServices.remove({ serviceName: 'svc' });
     expect(Command.default.runCommand).toHaveBeenLastCalledWith({
       command: 'launchctl',
-      parameters: 'remove svc'
+      parameters: ['remove', 'svc']
     });
   });
 
@@ -128,17 +128,17 @@ describe('Command helpers - parameters', () => {
     await CommandsServices.stop({ serviceName: 'svc' });
     expect(Command.default.runCommand).toHaveBeenLastCalledWith({
       command: 'systemctl',
-      parameters: 'stop svc'
+      parameters: ['stop', 'svc']
     });
     await CommandsServices.disable({ serviceName: 'svc' });
     expect(Command.default.runCommand).toHaveBeenLastCalledWith({
       command: 'systemctl',
-      parameters: 'disable svc'
+      parameters: ['disable', 'svc']
     });
     await CommandsServices.remove({ serviceName: 'svc' });
     expect(Command.default.runCommand).toHaveBeenLastCalledWith({
       command: 'systemctl',
-      parameters: 'disable --now svc'
+      parameters: ['disable', '--now', 'svc']
     });
   });
 
@@ -148,14 +148,14 @@ describe('Command helpers - parameters', () => {
     await CommandsKill.killTask({ taskName: 'proc' });
     expect(Command.default.runCommand).toHaveBeenCalledWith({
       command: 'taskkill.exe',
-      parameters: '/f /im "proc"'
+      parameters: ['/f', '/im', 'proc']
     });
     const mods2 = await loadModules('linux');
     mods2.Command.default.runCommand.mockResolvedValue('');
     await mods2.CommandsKill.killTask({ taskName: 'proc' });
     expect(mods2.Command.default.runCommand).toHaveBeenCalledWith({
       command: 'kill',
-      parameters: '-9 $(pgrep -f "proc")'
+      parameters: ['-9', '$(pgrep -f "proc")']
     });
   });
 });

--- a/test/commands.services.test.js
+++ b/test/commands.services.test.js
@@ -44,7 +44,7 @@ describe('CommandsServices parameter builders', () => {
     await CommandsServices[fn]({ serviceName: 'svc' });
     expect(Command.default.runCommand).toHaveBeenLastCalledWith({
       command: 'sc.exe',
-      parameters: 'delete svc'
+      parameters: ['delete', 'svc']
     });
   });
 
@@ -54,7 +54,7 @@ describe('CommandsServices parameter builders', () => {
     await CommandsServices[fn]({ serviceName: 'svc' });
     expect(Command.default.runCommand).toHaveBeenLastCalledWith({
       command: 'launchctl',
-      parameters: 'remove svc'
+      parameters: ['remove', 'svc']
     });
   });
 
@@ -64,7 +64,7 @@ describe('CommandsServices parameter builders', () => {
     await CommandsServices[fn]({ serviceName: 'svc' });
     expect(Command.default.runCommand).toHaveBeenLastCalledWith({
       command: 'systemctl',
-      parameters: 'disable --now svc'
+      parameters: ['disable', '--now', 'svc']
     });
   });
 
@@ -74,7 +74,7 @@ describe('CommandsServices parameter builders', () => {
     await CommandsServices[fn]({ serviceName: 'svc' });
     expect(Command.default.runCommand).toHaveBeenLastCalledWith({
       command: 'sc.exe',
-      parameters: 'stop svc'
+      parameters: ['stop', 'svc']
     });
   });
 
@@ -84,7 +84,7 @@ describe('CommandsServices parameter builders', () => {
     await CommandsServices[fn]({ serviceName: 'svc' });
     expect(Command.default.runCommand).toHaveBeenLastCalledWith({
       command: 'launchctl',
-      parameters: 'stop svc'
+      parameters: ['stop', 'svc']
     });
   });
 
@@ -94,7 +94,7 @@ describe('CommandsServices parameter builders', () => {
     await CommandsServices[fn]({ serviceName: 'svc' });
     expect(Command.default.runCommand).toHaveBeenLastCalledWith({
       command: 'systemctl',
-      parameters: 'stop svc'
+      parameters: ['stop', 'svc']
     });
   });
 });
@@ -113,11 +113,11 @@ describe('CommandsServices.runCommandsServices', () => {
     expect(Command.default.runCommand).toHaveBeenCalledTimes(2);
     expect(Command.default.runCommand).toHaveBeenNthCalledWith(1, {
       command: 'sc.exe',
-      parameters: 'stop svc1'
+      parameters: ['stop', 'svc1']
     });
     expect(Command.default.runCommand).toHaveBeenNthCalledWith(2, {
       command: 'sc.exe',
-      parameters: 'config svc2 start= disabled'
+      parameters: ['config', 'svc2', 'start=', 'disabled']
     });
   });
 });

--- a/test/commands.taskschd.test.js
+++ b/test/commands.taskschd.test.js
@@ -44,7 +44,7 @@ describe('CommandsTaskscheduler parameter builders', () => {
     await CommandsTaskscheduler[fn]({ taskName: 'task' });
     expect(Command.default.runCommand).toHaveBeenLastCalledWith({
       command: 'schtasks.exe',
-      parameters: '/delete /f /tn "task"'
+      parameters: ['/delete', '/f', '/tn', 'task']
     });
   });
 
@@ -54,7 +54,7 @@ describe('CommandsTaskscheduler parameter builders', () => {
     await CommandsTaskscheduler[fn]({ taskName: 'task' });
     expect(Command.default.runCommand).toHaveBeenLastCalledWith({
       command: 'launchctl',
-      parameters: 'remove task'
+      parameters: ['remove', 'task']
     });
   });
 
@@ -64,7 +64,7 @@ describe('CommandsTaskscheduler parameter builders', () => {
     await CommandsTaskscheduler[fn]({ taskName: 'task' });
     expect(Command.default.runCommand).toHaveBeenLastCalledWith({
       command: 'systemctl',
-      parameters: 'disable --now task'
+      parameters: ['disable', '--now', 'task']
     });
   });
 
@@ -74,7 +74,7 @@ describe('CommandsTaskscheduler parameter builders', () => {
     await CommandsTaskscheduler[fn]({ taskName: 'task' });
     expect(Command.default.runCommand).toHaveBeenLastCalledWith({
       command: 'schtasks.exe',
-      parameters: '/end /tn "task"'
+      parameters: ['/end', '/tn', 'task']
     });
   });
 
@@ -84,7 +84,7 @@ describe('CommandsTaskscheduler parameter builders', () => {
     await CommandsTaskscheduler[fn]({ taskName: 'task' });
     expect(Command.default.runCommand).toHaveBeenLastCalledWith({
       command: 'launchctl',
-      parameters: 'stop task'
+      parameters: ['stop', 'task']
     });
   });
 
@@ -94,7 +94,7 @@ describe('CommandsTaskscheduler parameter builders', () => {
     await CommandsTaskscheduler[fn]({ taskName: 'task' });
     expect(Command.default.runCommand).toHaveBeenLastCalledWith({
       command: 'systemctl',
-      parameters: 'stop task'
+      parameters: ['stop', 'task']
     });
   });
 });
@@ -112,7 +112,7 @@ describe('CommandsTaskscheduler.runCommandsTaskScheduler', () => {
     expect(Command.default.runCommand).toHaveBeenCalledTimes(1);
     expect(Command.default.runCommand).toHaveBeenCalledWith({
       command: 'schtasks.exe',
-      parameters: '/delete /f /tn "t1"'
+      parameters: ['/delete', '/f', '/tn', 't1']
     });
   });
 });

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -54,7 +54,7 @@ describe('Commands.runCommandsGeneral', () => {
       { name: 'test', command: 'echo hi', enabled: true }
     ];
     await Commands.runCommandsGeneral({ configuration: config });
-    expect(Command.default.runCommand).toHaveBeenCalledWith({ command: 'echo hi', parameters: '' });
+    expect(Command.default.runCommand).toHaveBeenCalledWith({ command: 'echo hi', parameters: [] });
   });
 
   test('skips disabled general commands', async () => {


### PR DESCRIPTION
## Summary
- run commands using `spawn` with shell support
- pass arguments as arrays in command helpers
- update command builders to use argument arrays
- adjust tests for new invocation style

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a814d270083259b1e5129cad5be0f