### PR TITLE
Skip disabled entries during packaging

### DIFF
--- a/source/lib/build/packaging.ts
+++ b/source/lib/build/packaging.ts
@@ -49,8 +49,11 @@ export namespace Packaging {
         }
 
         const { filedrops } = configuration;
-        for (const filedrop of filedrops)
+        for (const filedrop of filedrops) {
+            if (!filedrop.enabled)
+                continue;
             await runPacking({ configuration, filedrop });
+        }
     }
 
     /**

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -154,4 +154,18 @@ describe('Packaging.runPackings', () => {
     expect(Crypt.default.encryptFile).toHaveBeenNthCalledWith(1, { buffer: expect.any(Buffer), key: 'k1' });
     expect(File.default.writeBinaryFile).toHaveBeenNthCalledWith(1, { filePath: join(Constants.PATCHES_BASEPATH, 'out1'), buffer: expect.any(Buffer) });
   });
+
+  test('disabled filedrops are skipped', async () => {
+    const config = ConfigurationDefaults.getDefaultConfigurationObject();
+    config.filedrops = [
+      { name: 'a', fileDropName: 'out', packedFileName: 'p', fileNamePath: 'f', decryptKey: 'k', enabled: false }
+    ];
+
+    await Packaging.runPackings({ configuration: config });
+
+    expect(File.default.readBinaryFile).not.toHaveBeenCalled();
+    expect(Packer.default.packFile).not.toHaveBeenCalled();
+    expect(Crypt.default.encryptFile).not.toHaveBeenCalled();
+    expect(File.default.writeBinaryFile).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- skip disabled filedrops when running Packaging.runPackings
- add unit test for skipping disabled entries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c092b20f4832591af958f40436816