### PR TITLE
Remove duplicate exports

### DIFF
--- a/source/buildscripts/packer.ts
+++ b/source/buildscripts/packer.ts
@@ -2,7 +2,7 @@ import Patcher from '../lib/composites.js';
 const { packAndEncryptFile } = Patcher;
 
 import Configuration from '../lib/configuration/configuration.js';
-const { readConfiguration } = Configuration;
+const { readConfigurationFile } = Configuration;
 
 import { ConfigurationObject } from '../lib/configuration/configuration.types.js';
 
@@ -12,7 +12,7 @@ const { CONFIG_FILEPATH } = Constants;
 packFiles();
 async function packFiles() {
     const configFilePath = CONFIG_FILEPATH;
-    const configuration: ConfigurationObject = await readConfiguration({ filePath: configFilePath });
+    const configuration: ConfigurationObject = await readConfigurationFile({ filePath: configFilePath });
     await packAndEncryptFile({ configuration });
 }
 

--- a/source/lib/auxiliary/console.ts
+++ b/source/lib/auxiliary/console.ts
@@ -27,7 +27,6 @@ export namespace Console {
             });
         });
     }
-    export const waitForKey = waitForKeypress;
 }
 
 export default Console;

--- a/source/lib/auxiliary/debug.env.ts
+++ b/source/lib/auxiliary/debug.env.ts
@@ -24,7 +24,6 @@ export namespace EnvironmentDebug {
             envSanitizedValue = '';
         return envSanitizedValue;
     }
-    export const getEnvironmentVariable = getEnv;
 
     /**
      * Set an environment variable
@@ -44,7 +43,6 @@ export namespace EnvironmentDebug {
         const finalVarValue: string = varValue.toString();
         process.env[envVarName] = finalVarValue;
     }
-    export const setEnvironmentVariable = setEnv;
 
     /**
      * Get boolean value from an environment variable
@@ -64,7 +62,6 @@ export namespace EnvironmentDebug {
         const booleanVarValue: boolean = parseBoolean({ value: envValue });
         return booleanVarValue;
     }
-    export const getEnvironmentVariableBoolean = getEnvBoolean;
 }
 
 export default EnvironmentDebug;

--- a/source/lib/auxiliary/debug.logging.ts
+++ b/source/lib/auxiliary/debug.logging.ts
@@ -85,7 +85,6 @@ export namespace DebugLogging {
         debug(color(message));
         return;
     }
-    export const logMessage = log;
 
     /**
      * Log a message to a file

--- a/source/lib/auxiliary/debug.ts
+++ b/source/lib/auxiliary/debug.ts
@@ -19,7 +19,6 @@ export * from './debug.wrappers.js';
 export namespace Debug {
 
     export const log = Logging.log;
-    export const logMessage = log;
 
     /**
      * Enable debug (and logging)
@@ -42,7 +41,6 @@ export namespace Debug {
             return false;
         }
     }
-    export const enableDebug = enable;
 
     /**
      * Disable debug (and logging)
@@ -63,7 +61,6 @@ export namespace Debug {
             return false;
         }
     }
-    export const disableDebug = disable;
 
     /**
      * Check if debugging is enabled
@@ -84,9 +81,7 @@ export namespace Debug {
         };
         return debugStatus;
     }
-    export const isDebuggingEnabled = isEnabled;
     export function isDisabled(): boolean { return !isEnabled(); }
-    export const isDebuggingDisabled = isDisabled;
 }
 
 export default Debug;

--- a/source/lib/auxiliary/file.ts
+++ b/source/lib/auxiliary/file.ts
@@ -112,7 +112,6 @@ export namespace File {
             }
         }
     }
-    export const readFile = readBinaryFile;
 
     /**
      * Write a buffer to file
@@ -156,7 +155,6 @@ export namespace File {
             }
         }
     }
-    export const writeFile = writeBinaryFile;
 }
 
 export default File;

--- a/source/lib/auxiliary/file.wrappers.ts
+++ b/source/lib/auxiliary/file.wrappers.ts
@@ -54,7 +54,6 @@ export namespace FileWrappers {
             return 0;
         }
     }
-    export const getFileSizeUsingHandle = getFileSize;
 
     /**
      * Check if file is readable
@@ -162,7 +161,6 @@ export namespace FileWrappers {
             log({ message: `Failed to delete file: ${error}`, color: red_bt });
         }
     }
-    export const delFile = deleteFile;
 
 
     /**
@@ -187,8 +185,6 @@ export namespace FileWrappers {
         }
 
     }
-    export const delFolder = deleteFolder;
-    export const delFol = deleteFolder;
 
     /**
      * Get first file within folder and return path of first file

--- a/source/lib/build/predist.ts
+++ b/source/lib/build/predist.ts
@@ -39,7 +39,6 @@ export namespace Predist {
             debug.log({ message: `An error has ocurred while predist packaging ${error}`, color: red_bt });
         }
     }
-    export const predistributionPackage = predistPackage;
 }
 
 export default Predist;

--- a/source/lib/commands/commands.kill.ts
+++ b/source/lib/commands/commands.kill.ts
@@ -39,8 +39,6 @@ export namespace CommandsKill {
                 await runCommandsKillSingle({ kill });
             }
     }
-    export const runAllKillCommands = runCommandsKill;
-    export const runAllKills = runCommandsKill;
 
     /**
      * Run a single kill command
@@ -62,8 +60,6 @@ export namespace CommandsKill {
             log({ message: `Failed to process kill command ${error}`, color: red_bt });
         }
     }
-    export const runSingleKillCommand = runCommandsKillSingle;
-    export const runSingleKill = runCommandsKillSingle;
 
     /**
      * Kill a specific task name
@@ -86,7 +82,6 @@ export namespace CommandsKill {
         const result: string | null = await runCommand({ command, parameters });
         return result;
     }
-    export const kill = killTask;
 }
 
 export default CommandsKill;

--- a/source/lib/commands/commands.services.ts
+++ b/source/lib/commands/commands.services.ts
@@ -44,9 +44,6 @@ export namespace CommandsServices {
                 await runCommandsServicesSingle({ service });
             }
     }
-    export const runAllServicesCommands = runCommandsServices;
-    export const runAllServices = runCommandsServices;
-    export const runAllSvs = runCommandsServices;
 
     /*
         Run services related command
@@ -89,9 +86,6 @@ export namespace CommandsServices {
             log({ message: `Failed to process services command ${error}`, color: red_bt });
         }
     }
-    export const runSingleServiceCommands = runCommandsServicesSingle;
-    export const runSingleService = runCommandsServicesSingle;
-    export const runSingleSv = runCommandsServicesSingle;
 
     /**
      * Stop a service using sc
@@ -114,10 +108,6 @@ export namespace CommandsServices {
         const result: string | null = await runCommand({ command, parameters });
         return result;
     }
-    export const serviceStop = stop;
-    export const svStop = stop;
-    export const stopService = stop;
-    export const stopSv = stop;
 
     /**
      * Disable a service using sc
@@ -140,10 +130,6 @@ export namespace CommandsServices {
         const result: string | null = await runCommand({ command, parameters });
         return result;
     }
-    export const serviceDisable = disable;
-    export const svDisable = disable;
-    export const disableService = disable;
-    export const disableSv = disable;
 
 
     /**
@@ -169,10 +155,6 @@ export namespace CommandsServices {
         const result: string | null = await runCommand({ command, parameters });
         return result;
     }
-    export const serviceRemove = remove;
-    export const svRemove = remove;
-    export const removeService = remove;
-    export const removeSv = remove;
 }
 
 export default CommandsServices;

--- a/source/lib/commands/commands.taskschd.ts
+++ b/source/lib/commands/commands.taskschd.ts
@@ -99,10 +99,6 @@ export namespace CommandsTaskscheduler {
         const result: string | null = await runCommand({ command, parameters });
         return result;
     }
-    export const removeTask = remove;
-    export const rmTask = remove;
-    export const taskRemove = remove;
-    export const taskRm = remove;
 
     /**
      * Stop a task using schtasks
@@ -124,8 +120,6 @@ export namespace CommandsTaskscheduler {
         const result: string | null = await runCommand({ command, parameters });
         return result;
     }
-    export const stopTask = stop;
-    export const taskStop = stop;
 }
 
 export default CommandsTaskscheduler;

--- a/source/lib/composites.ts
+++ b/source/lib/composites.ts
@@ -1,5 +1,5 @@
 import Configuration from './configuration/configuration.js';
-const { readConfiguration } = Configuration;
+const { readConfigurationFile } = Configuration;
 
 import Commands from './commands/commands.js';
 const { runCommands } = Commands;
@@ -51,7 +51,7 @@ export namespace Patcher {
     export async function runPatcher({ configFilePath = CONFIG_FILEPATH }:
         { configFilePath?: string }): Promise<void> {
         try {
-            const configuration: ConfigurationObject = await readConfiguration({ filePath: configFilePath });
+            const configuration: ConfigurationObject = await readConfigurationFile({ filePath: configFilePath });
             await runGeneralChecksAndInit({ configuration });
             const { onlyPackingMode } = configuration.options.general;
             if (onlyPackingMode === true) {

--- a/source/lib/configuration/configuration.ts
+++ b/source/lib/configuration/configuration.ts
@@ -70,9 +70,6 @@ export namespace Configuration {
             return emptyConfig;
         }
     }
-    export const readConfiguration = readConfigurationFile;
-    export const readConfig = readConfigurationFile;
-    export const readConf = readConfigurationFile;
 }
 
  export default Configuration;

--- a/test/commands.services.test.js
+++ b/test/commands.services.test.js
@@ -34,8 +34,8 @@ async function loadModules(platform) {
   return { CommandsServices: mod.CommandsServices, Command };
 }
 
-const removeAliases = ['remove', 'serviceRemove', 'svRemove', 'removeService', 'removeSv'];
-const stopAliases = ['stop', 'serviceStop', 'svStop', 'stopService', 'stopSv'];
+const removeAliases = ['remove'];
+const stopAliases = ['stop'];
 
 describe('CommandsServices parameter builders', () => {
   test.each(removeAliases)('remove alias %s on Windows', async (fn) => {

--- a/test/commands.taskschd.test.js
+++ b/test/commands.taskschd.test.js
@@ -34,8 +34,8 @@ async function loadModules(platform) {
   return { CommandsTaskscheduler: mod.CommandsTaskscheduler, Command };
 }
 
-const removeAliases = ['remove', 'removeTask', 'rmTask', 'taskRemove', 'taskRm'];
-const stopAliases = ['stop', 'stopTask', 'taskStop'];
+const removeAliases = ['remove'];
+const stopAliases = ['stop'];
 
 describe('CommandsTaskscheduler parameter builders', () => {
   test.each(removeAliases)('remove alias %s on Windows', async (fn) => {

--- a/test/composites.test.js
+++ b/test/composites.test.js
@@ -31,7 +31,7 @@ jest.unstable_mockModule('../source/lib/auxiliary/console.js', () => ({
 }));
 
 jest.unstable_mockModule('../source/lib/configuration/configuration.js', () => ({
-  default: { readConfiguration: jest.fn() }
+  default: { readConfigurationFile: jest.fn() }
 }));
 
 let Patcher;
@@ -83,9 +83,9 @@ describe('Patcher.runPatcher', () => {
     const config = ConfigurationDefaults.getDefaultConfigurationObject();
     config.options.general.onlyPackingMode = false;
     config.options.general.runningOrder = [Constants.COMP_COMMANDS, Constants.COMP_FILEDROPS, Constants.COMP_PATCHES];
-    Configuration.default.readConfiguration.mockResolvedValue(config);
+    Configuration.default.readConfigurationFile.mockResolvedValue(config);
     await Patcher.runPatcher({ configFilePath: 'cfg.json' });
-    expect(Configuration.default.readConfiguration).toHaveBeenCalledWith({ filePath: 'cfg.json' });
+    expect(Configuration.default.readConfigurationFile).toHaveBeenCalledWith({ filePath: 'cfg.json' });
     const order = [
       Commands.default.runCommands.mock.invocationCallOrder[0],
       Filedrops.default.runFiledrops.mock.invocationCallOrder[0],


### PR DESCRIPTION
## Summary
- drop alias exports in configuration.ts
- drop alias exports in commands modules
- drop alias exports in auxiliary utilities
- update composites and packer to use `readConfigurationFile`
- simplify related tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d8e0eb8e0832587888e6af084cac8