### PR TITLE
Fix crypto typing

### DIFF
--- a/source/lib/auxiliary/debug.env.ts
+++ b/source/lib/auxiliary/debug.env.ts
@@ -38,7 +38,7 @@ export namespace EnvironmentDebug {
      * @since 0.0.1
      */    
     export function setEnv({ envVarName, varValue }:
-        { envVarName: string, varValue: string | any }): void {
+        { envVarName: string, varValue: string | boolean | Buffer }): void {
 
         const finalVarValue: string = varValue.toString();
         process.env[envVarName] = finalVarValue;

--- a/source/lib/commands/command.ts
+++ b/source/lib/commands/command.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'child_process';
+import { spawn, ChildProcessWithoutNullStreams } from 'child_process';
 
 import Debug from '../auxiliary/debug.js';
 const { log } = Debug;
@@ -50,7 +50,7 @@ export namespace Command {
         { command: string, parameters: string[] }): Promise<string> {
 
         return new Promise(function (resolve, reject) {
-            const childProcess: any = spawn(command, parameters, { shell: true });
+            const childProcess: ChildProcessWithoutNullStreams = spawn(command, parameters, { shell: true });
             let output: string = '';
             childProcess.stdout.on('data', function (data) {
                 output += data.toString();

--- a/source/lib/filedrops/crypt.ts
+++ b/source/lib/filedrops/crypt.ts
@@ -1,4 +1,4 @@
-import { BinaryLike, createCipheriv, createDecipheriv, randomBytes, pbkdf2Sync, CipherGCM } from 'crypto';
+import { BinaryLike, createCipheriv, createDecipheriv, randomBytes, pbkdf2Sync, CipherGCM, DecipherGCM, CipherGCMTypes } from 'crypto';
 
 import File from '../auxiliary/file.js';
 const { readBinaryFile } = File;
@@ -78,11 +78,10 @@ export namespace Encryption {
 
             const salt: Buffer = randomBytes(CRYPTO_SALT_RANDOMBYTES);
             const iv: BinaryLike = randomBytes(CRYPTO_IV_RANDOMBYTES);
-            const algorithm: string = CRYPTO_ALG;
+            const algorithm: CipherGCMTypes = CRYPTO_ALG;
             const iterations: number = CRYPTO_ITERATIONS;
             const encryptionKey: Buffer = deriveKeyFromPassword({ password: key, salt: salt, iterations: iterations });
 
-            // @ts-ignore
             const cipher: CipherGCM = createCipheriv(algorithm, encryptionKey, iv);
 
             log({ message: `Encrypting data`, color: white });
@@ -171,7 +170,7 @@ export namespace Encryption {
             const salt: Buffer = getSlicedData({ data: fileData, subsetOptions: bufferSubsets.salt });
             const iv: Buffer = getSlicedData({ data: fileData, subsetOptions: bufferSubsets.iv });
             const authTag: Buffer = getSlicedData({ data: fileData, subsetOptions: bufferSubsets.authTag });
-            const algorithm: string = CRYPTO_ALG;
+            const algorithm: CipherGCMTypes = CRYPTO_ALG;
             const iterations: Buffer = getSlicedData({ data: fileData, subsetOptions: bufferSubsets.iterations });
 
             const iterationsInt = parseInt(iterations.toString(), 10);
@@ -200,9 +199,7 @@ export namespace Encryption {
 
             log({ message: `Inner encrypted data length: ${innerEncryptedData.byteLength}`, color: white });
 
-            // @ts-ignore
-            const decipher: CipherGCM = createDecipheriv(algorithm, decryptionKey, iv);
-            // @ts-ignore
+            const decipher: DecipherGCM = createDecipheriv(algorithm, decryptionKey, iv);
             decipher.setAuthTag(authTag);
 
             log({ message: `Decrypting data`, color: white });

--- a/source/lib/patches/parser.ts
+++ b/source/lib/patches/parser.ts
@@ -64,7 +64,7 @@ export namespace Parser {
         try {
             const lines: number = patchData.length;
             log({ message: `Found ${lines} patch(es) inside patch data`, color: white });
-            let patches: PatchArray = [];
+            const patches: PatchArray = [];
             log({ message: `Pushing patch objects into an array`, color: white });
             for (const [index, patchLine] of patchData.entries()) {
                 const trimmed = patchLine.trim();


### PR DESCRIPTION
## Summary
- tighten crypto algorithm typing for AES-GCM
- remove TS ignores by assigning CipherGCM/DecipherGCM
- define precise types for command processes and environment vars
- fix lint error in parser

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686fed9139f083259d9c0dc7586832c3