### PR TITLE
Implement centralized logger

### DIFF
--- a/source/lib/auxiliary/file.ts
+++ b/source/lib/auxiliary/file.ts
@@ -8,11 +8,8 @@ const { isFileReadable, isFileWritable, getFileSize } = FileWrappers;
 
 import { FileHandle } from 'fs/promises';
 
-import Debug from './debug.js';
-const { log } = Debug;
-
-import colorsCli from 'colors-cli';
-const { green_bt, red_bt, white, yellow_bt } = colorsCli;
+import Logger from './logger.js';
+const { logInfo, logSuccess, logWarn, logError } = Logger;
 
 export * from './file.wrappers.js';
 
@@ -40,33 +37,33 @@ export namespace File {
         let fileHandle: FileHandle | undefined;
         try {
             const encoding: BufferEncoding = 'utf-8';
-            log({ message: `Opening file path, ${filePath}, in read mode`, color: white });
+            logInfo(`Opening file path, ${filePath}, in read mode`);
             const cantReadFile: boolean = !(await isFileReadable({ filePath }));
             if (cantReadFile)
                 throw new Error(`File is not readable, is missing or corrupted`);
             fileHandle = await fs.open(filePath);
             const bufferSize: number = await getFileSize({ fileHandle });
             if (bufferSize === 0)
-                log({ message: 'File size is 0, file may be corrupted or invalid', color: yellow_bt });
+                logWarn('File size is 0, file may be corrupted or invalid');
             else
-                log({ message: `Patch file size, ${bufferSize}`, color: green_bt });
-            log({ message: `Reading file handle with ${encoding} encoding`, color: white });
+                logSuccess(`Patch file size, ${bufferSize}`);
+            logInfo(`Reading file handle with ${encoding} encoding`);
             const fileData: string = await fileHandle.readFile({
                 encoding: encoding
             });
             const dataLength: number = fileData.length;
             if (dataLength === 0)
-                log({ message: `Patch file data size is 0, file may be corrupted or invalid`, color: yellow_bt });
+                logWarn(`Patch file data size is 0, file may be corrupted or invalid`);
             else
-                log({ message: `Read patch file successfully to buffer`, color: green_bt });
+                logSuccess(`Read patch file successfully to buffer`);
             return fileData;
         } catch (error: any) {
-            log({ message: `An error has occurred: ${error}`, color: red_bt });
+            logError(`An error has occurred: ${error}`);
             return '';
         } finally {
             if (fileHandle) {
                 await fileHandle.close();
-                log({ message: `Closed file handle`, color: white });
+                logInfo(`Closed file handle`);
             }
         }
     }
@@ -86,29 +83,29 @@ export namespace File {
         { filePath: string; }): Promise<Buffer> {
         let fileHandle: FileHandle | undefined;
         try {
-            log({ message: `Opening file path, ${filePath}, in read mode`, color: white });
+            logInfo(`Opening file path, ${filePath}, in read mode`);
             if (!(await isFileReadable({ filePath })))
                 throw new Error(`File is not readable, is missing or corrupted`);
             fileHandle = await fs.open(filePath);
-            log({ message: 'Getting file size', color: white });
+            logInfo('Getting file size');
             const bufferSize: number = await getFileSize({ fileHandle });
             if (bufferSize === 0)
-                log({ message: 'File size is 0, file may be corrupted or invalid', color: yellow_bt });
+                logWarn('File size is 0, file may be corrupted or invalid');
             else
-                log({ message: `Binary file size, ${bufferSize}`, color: green_bt });
-            log({ message: 'Creating buffer', color: white });
+                logSuccess(`Binary file size, ${bufferSize}`);
+            logInfo('Creating buffer');
             const buffer: Buffer = createBuffer({ size: bufferSize });
-            log({ message: 'Reading file handle to buffer', color: white });
+            logInfo('Reading file handle to buffer');
             await fileHandle.read(buffer, 0, bufferSize);
-            log({ message: 'Read binary file successfully to buffer', color: green_bt });
+            logSuccess('Read binary file successfully to buffer');
             return buffer;
         } catch (error: any) {
-            log({ message: `An error has occurred: ${error}`, color: red_bt });
+            logError(`An error has occurred: ${error}`);
             return createBuffer({ size: 0 });
         } finally {
             if (fileHandle) {
                 await fileHandle.close();
-                log({ message: 'Closed file handle', color: white });
+                logInfo('Closed file handle');
             }
         }
     }
@@ -130,28 +127,28 @@ export namespace File {
     }): Promise<number> {
         let fileHandle: fs.FileHandle | undefined;
         try {
-            log({ message: `Opening file path, ${filePath}, in write mode`, color: white });
+            logInfo(`Opening file path, ${filePath}, in write mode`);
             if (!(await isFileWritable({ filePath })))
                 throw new Error(`File is not writable, is missing or corrupted`);
             const flags: string = 'w';
             fileHandle = await fs.open(filePath, flags);
             const bufferSize: number = await getFileSize({ fileHandle });
             if (bufferSize === 0)
-                log({ message: 'File size is 0, file may be corrupted, invalid or is a new file/buffer', color: yellow_bt });
+                logWarn('File size is 0, file may be corrupted, invalid or is a new file/buffer');
             else
-                log({ message: `Binary file size, ${bufferSize}`, color: green_bt });
-            log({ message: 'Writing buffer to file handle', color: white });
+                logSuccess(`Binary file size, ${bufferSize}`);
+            logInfo('Writing buffer to file handle');
             const writeResult: { bytesWritten: number } = await fileHandle.write(buffer);
             const { bytesWritten } = writeResult;
-            log({ message: `Written ${bytesWritten} bytes to file`, color: green_bt });
+            logSuccess(`Written ${bytesWritten} bytes to file`);
             return bytesWritten;
         } catch (error: any) {
-            log({ message: `An error has occurred: ${error}`, color: red_bt });
+            logError(`An error has occurred: ${error}`);
             return 0;
         } finally {
             if (fileHandle) {
                 await fileHandle.close();
-                log({ message: 'Closed file handle', color: white });
+                logInfo('Closed file handle');
             }
         }
     }

--- a/source/lib/auxiliary/file.wrappers.ts
+++ b/source/lib/auxiliary/file.wrappers.ts
@@ -4,11 +4,8 @@ import { basename, join } from 'path';
 
 import { FileHandle } from 'fs/promises';
 
-import Debug from './debug.js';
-const { log } = Debug;
-
-import colorsCli from 'colors-cli';
-const { red_bt, white } = colorsCli;
+import Logger from './logger.js';
+const { logInfo, logError } = Logger;
 
 import Constants from '../configuration/constants.js';
 const { PATCHES_BACKUPEXT } = Constants;
@@ -156,9 +153,9 @@ export namespace FileWrappers {
         { filePath: string }): Promise<void> {
         try {
             await unlink(filePath);
-            log({ message: `Deleted file: ${filePath}`, color: white });
+            logInfo(`Deleted file: ${filePath}`);
         } catch (error) {
-            log({ message: `Failed to delete file: ${error}`, color: red_bt });
+            logError(`Failed to delete file: ${error}`);
         }
     }
 
@@ -179,9 +176,9 @@ export namespace FileWrappers {
 
         try {
             await rm(folderPath, { recursive: true });
-            log({ message: `Deleted folder: ${folderPath}`, color: white });
+            logInfo(`Deleted folder: ${folderPath}`);
         } catch (error) {
-            log({ message: `Failed to delete folder: ${error}`, color: red_bt });
+            logError(`Failed to delete folder: ${error}`);
         }
 
     }

--- a/source/lib/auxiliary/logger.ts
+++ b/source/lib/auxiliary/logger.ts
@@ -1,0 +1,24 @@
+import colorsCli from 'colors-cli';
+import Debug from './debug.js';
+const { log } = Debug;
+const { white, green_bt, yellow_bt, red_bt } = colorsCli;
+
+export namespace Logger {
+    export function logInfo(message: string): void {
+        log({ message, color: white });
+    }
+
+    export function logSuccess(message: string): void {
+        log({ message, color: green_bt });
+    }
+
+    export function logWarn(message: string): void {
+        log({ message, color: yellow_bt });
+    }
+
+    export function logError(message: string): void {
+        log({ message, color: red_bt });
+    }
+}
+
+export default Logger;

--- a/source/lib/auxiliary/uac.ts
+++ b/source/lib/auxiliary/uac.ts
@@ -2,11 +2,8 @@ import { exit } from 'process';
 
 import * as isElevated from 'elevated';
 
-import Debug from './debug.js';
-const { log } = Debug;
-
-import colorsCli from 'colors-cli';
-const { white, red_bt } = colorsCli;
+import Logger from './logger.js';
+const { logInfo, logError } = Logger;
 
 export namespace Uac {
     /**
@@ -23,7 +20,7 @@ export namespace Uac {
     export async function isAdmin(): Promise<boolean> {
         try {
             const isAdministrator: boolean = await isElevated.check();
-            log({ message: `Is current user admin: ${isAdministrator}`, color: white });
+            logInfo(`Is current user admin: ${isAdministrator}`);
             return isAdministrator;
         } catch {
             return false;
@@ -45,7 +42,7 @@ export namespace Uac {
         const isAdministrator: boolean = await isAdmin();
         const exitCode: number = 1;
         if (!isAdministrator) {
-            log({ message: `Exiting because user doesn't have administrator privileges'`, color: red_bt });
+            logError(`Exiting because user doesn't have administrator privileges'`);
             exit(exitCode);
         }
     }

--- a/source/lib/build/builder.ts
+++ b/source/lib/build/builder.ts
@@ -4,9 +4,8 @@ const { runCommand } = Command;
 //import { randomBytes } from 'crypto';
 
 import { Debug as debug } from '../auxiliary/debug.js';
-
-import colorsCli from 'colors-cli';
-const { white, green_bt } = colorsCli;
+import Logger from '../auxiliary/logger.js';
+const { logInfo, logSuccess } = Logger;
 
 export namespace Builder {
     /**
@@ -22,14 +21,14 @@ export namespace Builder {
      */
     export async function buildExecutable(): Promise<void> {
         debug.enable({ logging: false });
-        debug.log({ message: `Building executable`, color: white });
+        logInfo(`Building executable`);
 
-        debug.log({ message: `Creating blob`, color: white });
+        logInfo(`Creating blob`);
         const nodeBin: string = `node`;
         const blobParameters: string[] = ['--experimental-sea-config', 'sea-config.json'];
         await runCommand({ command: nodeBin, parameters: blobParameters });
 
-        debug.log({ message: `Copying node binary`, color: white });
+        logInfo(`Copying node binary`);
         const binaryName: string = process.platform === 'win32'
             ? `./sea/predist/patcherjs.exe`
             : `./sea/predist/patcherjs`;
@@ -37,15 +36,15 @@ export namespace Builder {
         await runCommand({ command: nodeBin, parameters: nodeCopyParameters });
 
         if (process.platform === 'win32') {
-            debug.log({ message: `Removing signature`, color: white });
+            logInfo(`Removing signature`);
             const signtoolBin: string = `signtool`;
             const signtoolUnsigningParameters: string[] = ['remove', '/s', binaryName];
             await runCommand({ command: signtoolBin, parameters: signtoolUnsigningParameters });
         } else {
-            debug.log({ message: `Skipping signature removal step on non-Windows platform`, color: white });
+            logInfo(`Skipping signature removal step on non-Windows platform`);
         }
 
-        debug.log({ message: `Injecting script`, color: white });
+        logInfo(`Injecting script`);
         const npxBin: string = `npx`;
         const fuseRandomBytes: string = `fce680ab2cc467b6e072b8b5df1996b2` //randomBytes(16).toString(`hex`);
         const injectionParameters: string[] = [
@@ -58,7 +57,7 @@ export namespace Builder {
         ];
         await runCommand({ command: npxBin, parameters: injectionParameters });
 
-        debug.log({ message: `Built unsigned node sea binary`, color: green_bt });
+        logSuccess(`Built unsigned node sea binary`);
 
         //debug.log({ message: `Signing binary`, color: white });
         //const signtoolSigningParameters: string = `sign /fd SHA256 ${binaryName}`;

--- a/source/lib/build/cleanup.ts
+++ b/source/lib/build/cleanup.ts
@@ -2,9 +2,8 @@ import { rm, mkdir } from 'fs/promises';
 import { join } from 'path';
 
 import { Debug as debug } from '../auxiliary/debug.js';
-
-import colorsCli from 'colors-cli';
-const { white, green_bt } = colorsCli;
+import Logger from '../auxiliary/logger.js';
+const { logInfo, logSuccess } = Logger;
 
 export namespace Cleanup {
     /**
@@ -20,7 +19,7 @@ export namespace Cleanup {
     */
     export async function cleanupBuild(): Promise<void> {
         debug.enable({ logging: false });
-        debug.log({ message: `Cleaning up build space`, color: white });
+        logInfo(`Cleaning up build space`);
 
         const deletePath = async (path: string, recursive: boolean = false) => {
             try {
@@ -30,35 +29,35 @@ export namespace Cleanup {
             }
         };
 
-        debug.log({ message: `Deleting ./sea/sea-prep.blob`, color: white });
+        logInfo(`Deleting ./sea/sea-prep.blob`);
         await deletePath(join('sea', 'sea-prep.blob'));
 
-        debug.log({ message: `Deleting ./sea/sea-archive.7z`, color: white });
+        logInfo(`Deleting ./sea/sea-archive.7z`);
         await deletePath(join('sea', 'sea-archive.7z'));
 
-        debug.log({ message: `Deleting ./sea/executable.js`, color: white });
+        logInfo(`Deleting ./sea/executable.js`);
         await deletePath(join('sea', 'executable.js'));
 
-        debug.log({ message: `Deleting ./sea/predist/* files`, color: white });
+        logInfo(`Deleting ./sea/predist/* files`);
         await deletePath(join('sea', 'predist'), true);
         await mkdir(join('sea', 'predist'), { recursive: true });
 
-        debug.log({ message: `Deleting ./sea/dist/* files`, color: white });
+        logInfo(`Deleting ./sea/dist/* files`);
         await deletePath(join('sea', 'dist'), true);
         await mkdir(join('sea', 'dist'), { recursive: true });
 
-        debug.log({ message: `Deleting ./dist/* files`, color: white });
+        logInfo(`Deleting ./dist/* files`);
         await deletePath('dist', true);
         await mkdir('dist', { recursive: true });
 
-        debug.log({ message: `Deleting ./docs/* files`, color: white });
+        logInfo(`Deleting ./docs/* files`);
         await deletePath('docs', true);
         await mkdir('docs', { recursive: true });
 
-        debug.log({ message: `Deleting ./tsconfig.tsbuildinfo`, color: white });
+        logInfo(`Deleting ./tsconfig.tsbuildinfo`);
         await deletePath('tsconfig.tsbuildinfo');
 
-        debug.log({ message: `Finished deleting build files`, color: green_bt });
+        logSuccess(`Finished deleting build files`);
     }
 }
 

--- a/source/lib/build/packaging.ts
+++ b/source/lib/build/packaging.ts
@@ -7,11 +7,8 @@ const { packFile } = Packer;
 import Encryption from '../filedrops/crypt.js';
 const { encryptFile } = Encryption;
 
-import Debug from '../auxiliary/debug.js';
-const { log } = Debug;
-
-import colorsCli from "colors-cli";
-const { red_bt, white, green_bt } = colorsCli;
+import Logger from '../auxiliary/logger.js';
+const { logInfo, logSuccess, logError } = Logger;
 import { join } from 'path';
 
 import {
@@ -41,10 +38,10 @@ export namespace Packaging {
      */
     export async function runPackings({ configuration }:
         { configuration: ConfigurationObject }): Promise<void> {
-        log({ message: `Running packing mode`, color: white });
+        logInfo(`Running packing mode`);
         const { runFiledrops } = configuration.options.filedrops;
         if (runFiledrops === false) {
-            log({ message: `Skipping packing due to runFiledrops configuration`, color: white });
+            logInfo(`Skipping packing due to runFiledrops configuration`);
             return;
         }
 
@@ -71,7 +68,7 @@ export namespace Packaging {
     async function runPacking({ configuration, filedrop }:
         { configuration: ConfigurationObject, filedrop: FiledropsObject }): Promise<void> {
         try {
-            log({ message: `Packing file ${filedrop.fileNamePath}`, color: white });
+            logInfo(`Packing file ${filedrop.fileNamePath}`);
             const filedropOptions: FiledropsOptionsObject = configuration.options.filedrops;
 
             let fileData: Buffer;
@@ -86,9 +83,9 @@ export namespace Packaging {
             await writeBinaryFile({
                 filePath: join(PATCHES_BASEPATH, filedrop.fileDropName), buffer: fileData
             });
-            log({ message: `File was packed successfully`, color: green_bt });
+            logSuccess(`File was packed successfully`);
         } catch (error) {
-            log({ message: `There was an error packing a file: ${error}`, color: red_bt });
+            logError(`There was an error packing a file: ${error}`);
         }
     }
 }

--- a/source/lib/build/predist.ts
+++ b/source/lib/build/predist.ts
@@ -1,9 +1,8 @@
 import Seven, { ZipStream } from 'node-7z';
 
 import { Debug as debug } from '../auxiliary/debug.js';
-
-import colorsCli from 'colors-cli';
-const { red_bt, white, green_bt } = colorsCli;
+import Logger from '../auxiliary/logger.js';
+const { logInfo, logSuccess, logError } = Logger;
 
 import Constants from '../configuration/constants.js';
 const { PACKMETHOD, SEVENZIPBIN_FILEPATH } = Constants;
@@ -25,18 +24,18 @@ export namespace Predist {
             const seaArchiveName: string = `sea-archive.7z`;
 
             debug.enable({ logging: false });
-            debug.log({ message: `Packaging ${seaArchiveName}`, color: white });
+            logInfo(`Packaging ${seaArchiveName}`);
             const options: {} = {
                 method: PACKMETHOD,
                 $bin: SEVENZIPBIN_FILEPATH
             };
             const packageStream: ZipStream = Seven.add(`./sea/${seaArchiveName}`, `./sea/predist/*`, options);
             packageStream.on('end', function () {
-                debug.log({ message: `Packaged ${seaArchiveName} successfully`, color: green_bt });
+                logSuccess(`Packaged ${seaArchiveName} successfully`);
             });
 
         } catch (error) {
-            debug.log({ message: `An error has ocurred while predist packaging ${error}`, color: red_bt });
+            logError(`An error has ocurred while predist packaging ${error}`);
         }
     }
 }

--- a/source/lib/commands/command.ts
+++ b/source/lib/commands/command.ts
@@ -1,10 +1,7 @@
 import { spawn } from 'child_process';
 
-import Debug from '../auxiliary/debug.js';
-const { log } = Debug;
-
-import colorsCli from 'colors-cli';
-const { red_bt } = colorsCli;
+import Logger from '../auxiliary/logger.js';
+const { logError } = Logger;
 
 export namespace Command { 
     /**
@@ -28,7 +25,7 @@ export namespace Command {
             if (error && typeof error === 'object')
                 if (String(error).length > 2) {
                     const errorMessage: string = String(error).replaceAll('\r\n', '')
-                    log({ message: `There was an error running a command: ${errorMessage}`, color: red_bt });
+                    logError(`There was an error running a command: ${errorMessage}`);
                 }
             return null;
         }

--- a/source/lib/commands/commands.additional.ts
+++ b/source/lib/commands/commands.additional.ts
@@ -1,10 +1,7 @@
 import * as path from 'path';
 
-import Debug from '../auxiliary/debug.js';
-const { log } = Debug;
-
-import colorsCli from 'colors-cli';
-const { white } = colorsCli;
+import Logger from '../auxiliary/logger.js';
+const { logInfo } = Logger;
 
 export namespace CommandsAdditional {
     /**
@@ -35,7 +32,7 @@ export namespace CommandsAdditional {
             }
 
             const resolvedPath: string = path.resolve(alias);
-            log({ message: `Resolved ${alias} to ${resolvedPath}`, color: white });
+            logInfo(`Resolved ${alias} to ${resolvedPath}`);
             return resolvedPath;
         } catch {
             return '';

--- a/source/lib/commands/commands.kill.ts
+++ b/source/lib/commands/commands.kill.ts
@@ -1,11 +1,8 @@
 import Command from './command.js';
 const { runCommand } = Command;
 
-import Debug from '../auxiliary/debug.js';
-const { log } = Debug;
-
-import colorsCli from 'colors-cli';
-const { red_bt, white } = colorsCli;
+import Logger from '../auxiliary/logger.js';
+const { logInfo, logError } = Logger;
 
 import {
     CommandKillObject,
@@ -35,7 +32,7 @@ export namespace CommandsKill {
         const killList = configuration.commands.kill;
         for (const kill of killList)
             if (kill.enabled === true) {
-                log({ message: `Killing process ${kill.name}`, color: white });
+                logInfo(`Killing process ${kill.name}`);
                 await runCommandsKillSingle({ kill });
             }
     }
@@ -57,7 +54,7 @@ export namespace CommandsKill {
             const taskName: string = kill.name;
             await killTask({ taskName });
         } catch (error) {
-            log({ message: `Failed to process kill command ${error}`, color: red_bt });
+            logError(`Failed to process kill command ${error}`);
         }
     }
 

--- a/source/lib/commands/commands.services.ts
+++ b/source/lib/commands/commands.services.ts
@@ -1,11 +1,8 @@
 import Command from './command.js';
 const { runCommand } = Command;
 
-import Debug from '../auxiliary/debug.js';
-const { log } = Debug;
-
-import colorsCli from 'colors-cli';
-const { red_bt, white } = colorsCli;
+import Logger from '../auxiliary/logger.js';
+const { logInfo, logError } = Logger;
 
 import {
     CommandServicesObject,
@@ -40,7 +37,7 @@ export namespace CommandsServices {
         const { services } = configuration.commands;
         for (const service of services)
             if (service.enabled === true) {
-                log({ message: `Running services function ${service.command} to ${service.name}`, color: white });
+                logInfo(`Running services function ${service.command} to ${service.name}`);
                 await runCommandsServicesSingle({ service });
             }
     }
@@ -67,15 +64,15 @@ export namespace CommandsServices {
             const serviceName: string = service.name;
             switch (functionName) {
                 case COMM_SERVICES_STOP:
-                    log({ message: `Stopping service ${serviceName}`, color: white });
+                    logInfo(`Stopping service ${serviceName}`);
                     await stop({ serviceName });
                     break;
                 case COMM_SERVICES_DISABLE:
-                    log({ message: `Disabling service ${serviceName}`, color: white });
+                    logInfo(`Disabling service ${serviceName}`);
                     await disable({ serviceName });
                     break;
                 case COMM_SERVICES_REMOVE:
-                    log({ message: `Removing service ${serviceName}`, color: white });
+                    logInfo(`Removing service ${serviceName}`);
                     await remove({ serviceName });
                     break;
                 default:
@@ -83,7 +80,7 @@ export namespace CommandsServices {
             }
 
         } catch (error) {
-            log({ message: `Failed to process services command ${error}`, color: red_bt });
+            logError(`Failed to process services command ${error}`);
         }
     }
 

--- a/source/lib/commands/commands.taskschd.ts
+++ b/source/lib/commands/commands.taskschd.ts
@@ -1,11 +1,8 @@
 import Command from './command.js';
 const { runCommand } = Command;
 
-import Debug from '../auxiliary/debug.js';
-const { log } = Debug;
-
-import colorsCli from 'colors-cli';
-const { red_bt, white } = colorsCli;
+import Logger from '../auxiliary/logger.js';
+const { logInfo, logError } = Logger;
 
 import {
     CommandTaskSchedulerObject,
@@ -38,7 +35,7 @@ export namespace CommandsTaskscheduler {
         const { tasks } = configuration.commands;
         for (const task of tasks)
             if (task.enabled === true) {
-                log({ message: `Running task scheduler function ${task.command} to ${task.name}`, color: white });
+                logInfo(`Running task scheduler function ${task.command} to ${task.name}`);
                 await runCommandsTaskSchedulerSingle({ task });
             }
     }
@@ -61,11 +58,11 @@ export namespace CommandsTaskscheduler {
             const taskName: string = task.name;
             switch (functionName) {
                 case COMM_TASKS_DELETE:
-                    log({ message: `Deleting scheduled task ${taskName}`, color: white });
+                    logInfo(`Deleting scheduled task ${taskName}`);
                     await remove({ taskName });
                     break;
                 case COMM_TASKS_STOP:
-                    log({ message: `Stopping scheduled task ${taskName}`, color: white });
+                    logInfo(`Stopping scheduled task ${taskName}`);
                     await stop({ taskName });
                     break;
                 default:
@@ -73,7 +70,7 @@ export namespace CommandsTaskscheduler {
             }
 
         } catch (error) {
-            log({ message: `Failed to process task scheduler command ${error}`, color: red_bt });
+            logError(`Failed to process task scheduler command ${error}`);
         }
     }
 

--- a/source/lib/commands/commands.ts
+++ b/source/lib/commands/commands.ts
@@ -10,11 +10,8 @@ const { runCommandsKill } = CommandsKill;
 import Command from './command.js';
 const { runCommand } = Command;
 
-import Debug from '../auxiliary/debug.js';
-const { log } = Debug;
-
-import colorsCli from 'colors-cli';
-const { red_bt, white } = colorsCli;
+import Logger from '../auxiliary/logger.js';
+const { logInfo, logError } = Logger;
 
 import {
     ConfigurationObject
@@ -50,7 +47,7 @@ export namespace Commands {
         { configuration: ConfigurationObject }): Promise<void> {
         const { runCommands } = configuration.options.commands;
         if (runCommands === false) {
-            log({ message: `Skipping running commands due to configuration`, color: white });
+            logInfo(`Skipping running commands due to configuration`);
             return;
         }
 
@@ -92,7 +89,7 @@ export namespace Commands {
                     throw new Error(`Unknown command type: ${functionName}`);
             }
         } catch (error) {
-            log({ message: `Failed to process command type ${error}`, color: red_bt });
+            logError(`Failed to process command type ${error}`);
         }
     }
 
@@ -112,7 +109,7 @@ export namespace Commands {
         const commands = configuration.commands.general;
         for (const command of commands)
             if (command.enabled === true) {
-                log({ message: `Running general command ${command.name}: ${command.command}`, color: white });
+                logInfo(`Running general command ${command.name}: ${command.command}`);
                 await runCommand({ command: command.command, parameters: [] });
             }
     }

--- a/source/lib/composites.ts
+++ b/source/lib/composites.ts
@@ -16,10 +16,9 @@ const { runPackings } = Packaging;
 import Uac from './auxiliary/uac.js';
 const { adminCheck } = Uac;
 
+import Logger from './auxiliary/logger.js';
+const { logInfo, logSuccess, logError } = Logger;
 import Debug from './auxiliary/debug.js';
-
-import colorsCli from 'colors-cli';
-const { green_bt, red_bt, white } = colorsCli;
 
 import Console from './auxiliary/console.js';
 const { waitForKeypress } = Console;
@@ -62,10 +61,10 @@ export namespace Patcher {
                     await runFunction({ configuration, functionName: nextFunction });
             }
         } catch (error) {
-            Debug.log({ message: `There was an error running patcher: ${error}`, color: red_bt });
+            logError(`There was an error running patcher: ${error}`);
         } finally {
-            Debug.log({ message: `Patcher finished running`, color: green_bt });
-            Debug.log({ message: `Press any key to close application...`, color: white });
+            logSuccess(`Patcher finished running`);
+            logInfo(`Press any key to close application...`);
             await waitForKeypress();
         }
     }
@@ -86,7 +85,7 @@ export namespace Patcher {
         try {
             await runPackings({ configuration });
         } catch (error) {
-            Debug.log({ message: `Failed to run pack and encrypt file function`, color: red_bt });
+            logError(`Failed to run pack and encrypt file function`);
         }
     }
 
@@ -119,7 +118,7 @@ export namespace Patcher {
                     throw new Error(`Unknown function: ${functionName}`);
             }
         } catch (error) {
-            Debug.log({ message: `Failed to process function ${error}`, color: red_bt });
+            logError(`Failed to process function ${error}`);
             return;
         }
     }

--- a/source/lib/configuration/configuration.ts
+++ b/source/lib/configuration/configuration.ts
@@ -6,11 +6,8 @@ const { getFileSize, isFileReadable } = FileWrappers;
 import Defaults from './configuration.defaults.js';
 const { getDefaultConfigurationObject } = Defaults;
 
-import Debug from '../auxiliary/debug.js';
-const { log } = Debug;
-
-import colorsCli from 'colors-cli';
-const { green_bt, red_bt, white, yellow_bt } = colorsCli;
+import Logger from '../auxiliary/logger.js';
+const { logInfo, logSuccess, logWarn, logError } = Logger;
 
 import {
     ConfigurationObject
@@ -48,24 +45,24 @@ export namespace Configuration {
             const fileHandle: fs.FileHandle = await fs.open(filePath);
             const bufferSize: number = await getFileSize({ fileHandle });
             if (bufferSize === 0)
-                log({ message: 'Configuration file size is 0, file may be corrupted or invalid', color: yellow_bt });
+                logWarn('Configuration file size is 0, file may be corrupted or invalid');
             else
-                log({ message: `Configuration file size, ${bufferSize}`, color: green_bt });
-            log({ message: `Reading configuration file handle with ${encoding} encoding`, color: white });
+                logSuccess(`Configuration file size, ${bufferSize}`);
+            logInfo(`Reading configuration file handle with ${encoding} encoding`);
             const fileData: string = await fileHandle.readFile({
                 encoding: encoding
             });
             const dataLength: number = fileData.length;
             if (dataLength === 0)
-                log({ message: `Configuration file data size is 0, file may be corrupted or invalid`, color: yellow_bt });
+                logWarn(`Configuration file data size is 0, file may be corrupted or invalid`);
             else
-                log({ message: `Configuration file read successfully`, color: green_bt });
+                logSuccess(`Configuration file read successfully`);
             await fileHandle.close();
-            log({ message: `Closed file handle`, color: white });
+            logInfo(`Closed file handle`);
             const configObject: ConfigurationObject = JSON.parse(fileData);
             return configObject;
         } catch (error: any) {
-            log({ message: `An error has occurred: ${error}`, color: red_bt });
+            logError(`An error has occurred: ${error}`);
             const emptyConfig: ConfigurationObject = getDefaultConfigurationObject();
             return emptyConfig;
         }

--- a/source/lib/filedrops/crypt.ts
+++ b/source/lib/filedrops/crypt.ts
@@ -9,11 +9,8 @@ const { getFilename } = Packer;
 import BufferWrappers from '../patches/buffer.wrappers.js';
 const { createBuffer } = BufferWrappers;
 
-import Debug from '../auxiliary/debug.js';
-const { log } = Debug;
-
-import colorsCli from 'colors-cli';
-const { red_bt, white, yellow_bt } = colorsCli;
+import Logger from '../auxiliary/logger.js';
+const { logInfo, logWarn, logError } = Logger;
 
 import {
     CryptBufferSubsets,
@@ -62,15 +59,15 @@ export namespace Encryption {
 
             if (filePath && typeof filePath !== 'undefined' && typeof filePath === 'string') {
                 const filename: string = getFilename({ filePath });
-                log({ message: `Reading file to encrypt ${filename}`, color: white });
+                logInfo(`Reading file to encrypt ${filename}`);
                 fileData = await readBinaryFile({ filePath });
             } else {
-                log({ message: `Reading buffer to encrypt`, color: white });
+                logInfo(`Reading buffer to encrypt`);
                 if (buffer && typeof buffer !== 'undefined' && Buffer.isBuffer(buffer) === true) {
                     fileData = buffer;
                 } else {
                     fileData = createBuffer({ size: 0 });
-                    log({ message: `Encryption will probably fail because buffer is empty`, color: yellow_bt });
+                    logWarn(`Encryption will probably fail because buffer is empty`);
                 }
             }
 
@@ -85,7 +82,7 @@ export namespace Encryption {
             // @ts-ignore
             const cipher: CipherGCM = createCipheriv(algorithm, encryptionKey, iv);
 
-            log({ message: `Encrypting data`, color: white });
+            logInfo(`Encrypting data`);
 
             const encryptedData: Buffer = Buffer.concat([
                 Buffer.from(cipher.update(fileData, CRYPTO_ENCODING)),
@@ -96,13 +93,13 @@ export namespace Encryption {
             const authTag: Buffer = cipher.getAuthTag();
             const dataPrefix: Buffer = Buffer.from(getEncryptedPrefix());
 
-            log({ message: `Generated salt: (${salt.byteLength}) ${salt.toString(`hex`)}`, color: white });
-            log({ message: `Generated IV: (${iv.byteLength}) ${Buffer.from(iv).toString(`hex`)}`, color: white });
-            log({ message: `AuthTag: (${authTag.byteLength}) ${authTag.toString(`hex`)}`, color: white });
-            log({ message: `Detected iterations: ${iterations}`, color: white });
+            logInfo(`Generated salt: (${salt.byteLength}) ${salt.toString(`hex`)}`);
+            logInfo(`Generated IV: (${iv.byteLength}) ${Buffer.from(iv).toString(`hex`)}`);
+            logInfo(`AuthTag: (${authTag.byteLength}) ${authTag.toString(`hex`)}`);
+            logInfo(`Detected iterations: ${iterations}`);
 
-            log({ message: `Input key: ${key.slice(0, 4)}...${key.slice(-4)}`, color: white });
-            log({ message: `Computed encryption key: ${encryptionKey.toString(`hex`).slice(0, 6)}...${encryptionKey.toString(`hex`).slice(-6)}`, color: white });
+            logInfo(`Input key: ${key.slice(0, 4)}...${key.slice(-4)}`);
+            logInfo(`Computed encryption key: ${encryptionKey.toString(`hex`).slice(0, 6)}...${encryptionKey.toString(`hex`).slice(-6)}`);
 
             const outputDataBuffer: Buffer = Buffer.concat([
                 dataPrefix,
@@ -115,7 +112,7 @@ export namespace Encryption {
 
             return outputDataBuffer;
         } catch (error) {
-            log({ message: `There was an error encrypting: ${error}`, color: red_bt });
+            logError(`There was an error encrypting: ${error}`);
             return createBuffer({ size: 0 });
         }
     }
@@ -140,15 +137,15 @@ export namespace Encryption {
 
             if (filePath && typeof filePath !== 'undefined' && typeof filePath === 'string') {
                 const filename: string = getFilename({ filePath });
-                log({ message: `Reading file to decrypt ${filename}`, color: white });
+                logInfo(`Reading file to decrypt ${filename}`);
                 fileData = await readBinaryFile({ filePath });
             } else {
-                log({ message: `Reading buffer to decrypt`, color: white });
+                logInfo(`Reading buffer to decrypt`);
                 if (buffer && typeof buffer !== 'undefined' && Buffer.isBuffer(buffer) === true) {
                     fileData = buffer;
                 } else {
                     fileData = createBuffer({ size: 0 });
-                    log({ message: `Decryption will probably fail because buffer is empty`, color: yellow_bt });
+                    logWarn(`Decryption will probably fail because buffer is empty`);
                 }
             }
 
@@ -161,7 +158,7 @@ export namespace Encryption {
             // const fileDataHexConverted: Buffer = Buffer.from(fileData.toString('hex'));
 
             const packedPrefixString: string = (getSlicedData({ data: fileData, subsetOptions: bufferSubsets.prefix })).toString();
-            log({ message: `Detected pack prefix: ${packedPrefixString}`, color: white });
+            logInfo(`Detected pack prefix: ${packedPrefixString}`);
 
             if (dataPrefix !== packedPrefixString)
                 throw new Error(`May have not be encrypted using patcher`);
@@ -176,10 +173,10 @@ export namespace Encryption {
 
             const iterationsInt = parseInt(iterations.toString(), 10);
 
-            log({ message: `Detected salt: (${salt.byteLength}) ${salt.toString(`hex`)}`, color: white });
-            log({ message: `Detected IV: (${iv.byteLength}) ${iv.toString(`hex`)}`, color: white });
-            log({ message: `Detected authTag: (${authTag.byteLength}) ${authTag.toString(`hex`)}`, color: white });
-            log({ message: `Detected iterations: ${iterationsInt}`, color: white });
+            logInfo(`Detected salt: (${salt.byteLength}) ${salt.toString(`hex`)}`);
+            logInfo(`Detected IV: (${iv.byteLength}) ${iv.toString(`hex`)}`);
+            logInfo(`Detected authTag: (${authTag.byteLength}) ${authTag.toString(`hex`)}`);
+            logInfo(`Detected iterations: ${iterationsInt}`);
 
             /*
             const test: Buffer = getSlicedData({ data: fileData, subsetOptions: { offset: 0, bytes: 110 } });
@@ -195,17 +192,17 @@ export namespace Encryption {
 
             const decryptionKey: Buffer = deriveKeyFromPassword({ password: key, salt: salt, iterations: iterationsInt });
 
-            log({ message: `Input key: ${key.slice(0, 4)}...${key.slice(-4)}`, color: white });
-            log({ message: `Computed decryption key: ${decryptionKey.toString(`hex`).slice(0, 6)}...${decryptionKey.toString(`hex`).slice(-6)}`, color: white });
+            logInfo(`Input key: ${key.slice(0, 4)}...${key.slice(-4)}`);
+            logInfo(`Computed decryption key: ${decryptionKey.toString(`hex`).slice(0, 6)}...${decryptionKey.toString(`hex`).slice(-6)}`);
 
-            log({ message: `Inner encrypted data length: ${innerEncryptedData.byteLength}`, color: white });
+            logInfo(`Inner encrypted data length: ${innerEncryptedData.byteLength}`);
 
             // @ts-ignore
             const decipher: CipherGCM = createDecipheriv(algorithm, decryptionKey, iv);
             // @ts-ignore
             decipher.setAuthTag(authTag);
 
-            log({ message: `Decrypting data`, color: white });
+            logInfo(`Decrypting data`);
             const decryptedData: Buffer = Buffer.concat([
                 decipher.update(innerEncryptedData),
                 decipher.final()
@@ -213,7 +210,7 @@ export namespace Encryption {
 
             return decryptedData;
         } catch (error) {
-            log({ message: `There was an error decrypting: ${error}`, color: red_bt });
+            logError(`There was an error decrypting: ${error}`);
             return createBuffer({ size: 0 });
         }
     }
@@ -235,7 +232,7 @@ export namespace Encryption {
         const { offset, bytes } = subsetOptions;
         const sanitizedBytes: number = parseInt(bytes ? bytes.toString() : data.byteLength.toString());
         const limit: number = Math.min(offset + sanitizedBytes, data.length);
-        log({ message: `reading offset at ${offset}, ${limit} bytes`, color: white });
+        logInfo(`reading offset at ${offset}, ${limit} bytes`);
         if (offset >= data.length)
             throw new Error(`Offset sliced data out of range, it can happen if file is invalid or corrupted`);
         return data.subarray(offset, limit);

--- a/source/lib/filedrops/filedrops.ts
+++ b/source/lib/filedrops/filedrops.ts
@@ -7,11 +7,8 @@ const { decryptFile } = Crypt;
 import File from '../auxiliary/file.js';
 const { backupFile, readBinaryFile, writeBinaryFile } = File;
 
-import Debug from '../auxiliary/debug.js';
-const { log } = Debug;
-
-import colorsCli from 'colors-cli';
-const { red_bt, white, green_bt } = colorsCli;
+import Logger from '../auxiliary/logger.js';
+const { logInfo, logError, logSuccess } = Logger;
 import { join } from 'path';
 
 import { ConfigurationObject, FiledropsObject, FiledropsOptionsObject } from '../configuration/configuration.types.js';
@@ -35,7 +32,7 @@ export namespace Filedrops {
         { configuration: ConfigurationObject }): Promise<void> {
         const { runFiledrops } = configuration.options.filedrops;
         if (runFiledrops === false) {
-            log({ message: `Skipping filedrops due to configuration`, color: white });
+            logInfo(`Skipping filedrops due to configuration`);
             return;
         }
         const { filedrops } = configuration;
@@ -71,9 +68,9 @@ export namespace Filedrops {
             if (isFiledropPacked === true)
                 fileData = await unpackFile({ buffer: fileData, password: filedrop.decryptKey });
             await writeBinaryFile({ filePath: filedrop.fileNamePath, buffer: fileData });
-            log({ message: `File was dropped successfully`, color: green_bt });
+            logSuccess(`File was dropped successfully`);
         } catch (error) {
-            log({ message: `There was an error while dropping a file: ${error}`, color: red_bt });
+            logError(`There was an error while dropping a file: ${error}`);
         }
     }
 
@@ -94,7 +91,7 @@ export namespace Filedrops {
         const { backupFiles } = filedropOptions;
         const filePath: string = filedrop.fileNamePath;
         if (backupFiles === true) {
-            log({ message: `Backing up files due to backup files option`, color: white });
+            logInfo(`Backing up files due to backup files option`);
             await backupFile({ filePath });
         }
     }

--- a/source/lib/filedrops/packer.ts
+++ b/source/lib/filedrops/packer.ts
@@ -5,10 +5,8 @@ import { basename, extname } from 'path';
 import File from '../auxiliary/file.js';
 const { deleteFile, deleteFolder, firstFilenameInFolder, readBinaryFile, writeBinaryFile } = File;
 
-import Debug from '../auxiliary/debug.js';
-const { log } = Debug;
-import colorsCli from 'colors-cli';
-const { white, yellow_bt } = colorsCli;
+import Logger from '../auxiliary/logger.js';
+const { logInfo, logWarn } = Logger;
 
 import Constants from '../configuration/constants.js';
 const { SEVENZIPBIN_FILEPATH, PACKFILEEXTENSION, PACKMETHOD } = Constants;
@@ -32,7 +30,7 @@ export namespace Packer {
      */
     export async function packFile({ archivePath, buffer, password, preserveSource = true }:
         { archivePath?: string, buffer?: Buffer, password: string, preserveSource?: boolean }): Promise<Buffer> {
-        log({ message: `Packing file`, color: white });
+        logInfo(`Packing file`);
         let sourcePath: string;
         let usedTemp = false;
         if (archivePath) {
@@ -44,14 +42,14 @@ export namespace Packer {
                 sourcePath = tempFilePath;
                 usedTemp = true;
             } else {
-                log({ message: `Failed to get buffer or path, packing will fail`, color: yellow_bt });
+                logWarn(`Failed to get buffer or path, packing will fail`);
                 sourcePath = '';
             }
         }
 
-        log({ message: `Pack source path is ${sourcePath}`, color: white });
+        logInfo(`Pack source path is ${sourcePath}`);
         const destinationPath: string = getPackedPath({ filePath: sourcePath });
-        log({ message: `Pack destination path is ${destinationPath}`, color: white });
+        logInfo(`Pack destination path is ${destinationPath}`);
         const options: {} = {
             method: PACKMETHOD,
             $bin: SEVENZIPBIN_FILEPATH,
@@ -60,7 +58,7 @@ export namespace Packer {
 
         try {
             await packFileWrapper({ destinationPath, sourcePath, options });
-            log({ message: `Packed file successfully`, color: white });
+            logInfo(`Packed file successfully`);
             const packedBuffer: Buffer = await readBinaryFile({ filePath: destinationPath });
             return packedBuffer;
         } finally {
@@ -87,7 +85,7 @@ export namespace Packer {
     export async function packFileWrapper({ destinationPath, sourcePath, options }:
         { destinationPath: string, sourcePath: string | string[], options: {} }): Promise<void> {
         return new Promise(function (resolve, reject) {
-            log({ message: `Running pack file wrapper`, color: white });
+            logInfo(`Running pack file wrapper`);
             const extractor: ZipStream = Seven.add(
                 destinationPath,
                 sourcePath,
@@ -129,7 +127,7 @@ export namespace Packer {
 
         const extractionPath: string = `${archivePath}-extracted`;
 
-        log({ message: `Unpacking file: ${archivePath}`, color: white });
+        logInfo(`Unpacking file: ${archivePath}`);
 
         const options: {} = {
             $bin: SEVENZIPBIN_FILEPATH,

--- a/source/lib/index.ts
+++ b/source/lib/index.ts
@@ -16,6 +16,7 @@ export * from './build/packaging.js';
 export * from './patches/parser.js';
 export * from './patches/patches.js';
 export * from './auxiliary/uac.js';
+export * from './auxiliary/logger.js';
 export * from './composites.js';
 
 export default Patcher;

--- a/source/lib/patches/buffer.wrappers.ts
+++ b/source/lib/patches/buffer.wrappers.ts
@@ -1,8 +1,5 @@
-import Debug from '../auxiliary/debug.js';
-const { log } = Debug;
-
-import colorsCli from 'colors-cli';
-const { white } = colorsCli;
+import Logger from '../auxiliary/logger.js';
+const { logInfo } = Logger;
 
 export namespace BufferWrappers {
     /**
@@ -21,7 +18,7 @@ export namespace BufferWrappers {
 
         const newBuffer: Buffer = Buffer.alloc(size);
         const newBufferSize: number = newBuffer.byteLength;
-        log({ message: `Created buffer with size: ${newBufferSize}`, color: white });
+        logInfo(`Created buffer with size: ${newBufferSize}`);
         return newBuffer;
     }
 }

--- a/source/lib/patches/parser.ts
+++ b/source/lib/patches/parser.ts
@@ -1,11 +1,8 @@
 import ParserWrappers from './parser.wrappers.js';
 const { hexParse, hexParseBig, splitLines } = ParserWrappers;
 
-import Debug from '../auxiliary/debug.js';
-const { log } = Debug;
-
-import colorsCli from 'colors-cli';
-const { green_bt, red_bt, white } = colorsCli;
+import Logger from '../auxiliary/logger.js';
+const { logInfo, logSuccess, logError } = Logger;
 
 import {
     PatchArray,
@@ -33,17 +30,17 @@ export namespace Parser {
             const dataLength: number = fileData.length;
             if (dataLength === 0)
                 throw new Error(`Patch file data is empty or corrupted`);
-            log({ message: `Splitting file lines`, color: white });
+            logInfo(`Splitting file lines`);
             let patchData: string[] = splitLines({ fileData });
             // remove empty lines that may appear due to trailing newlines
             patchData = patchData.filter((line) => line.trim().length > 0);
-            log({ message: `Building patch objects array`, color: white });
+            logInfo(`Building patch objects array`);
             const patches: PatchArray = buildPatchesArray({ patchData });
             const patchesCount: number = patches.length;
-            log({ message: `Patch objects array built with ${patchesCount}`, color: green_bt });
+            logSuccess(`Patch objects array built with ${patchesCount}`);
             return patches;
         } catch (error: any) {
-            log({ message: `An error has occurred: ${error}`, color: red_bt });
+            logError(`An error has occurred: ${error}`);
             return new Array();
         }
     }
@@ -63,9 +60,9 @@ export namespace Parser {
         { patchData: string[] }): PatchArray {
         try {
             const lines: number = patchData.length;
-            log({ message: `Found ${lines} patch(es) inside patch data`, color: white });
+            logInfo(`Found ${lines} patch(es) inside patch data`);
             let patches: PatchArray = [];
-            log({ message: `Pushing patch objects into an array`, color: white });
+            logInfo(`Pushing patch objects into an array`);
             for (const [index, patchLine] of patchData.entries()) {
                 const trimmed = patchLine.trim();
                 if (trimmed.length === 0)
@@ -76,10 +73,10 @@ export namespace Parser {
             const patchesPushed: number = patches.length;
             if (patchesPushed === 0)
                 throw new Error(`There were 0 patch objects pushed to the patches array`);
-            log({ message: `There were ${patchesPushed} patch objects pushed`, color: green_bt });
+            logSuccess(`There were ${patchesPushed} patch objects pushed`);
             return patches;
         } catch (error: any) {
-            log({ message: `An error has occurred: ${error}`, color: red_bt });
+            logError(`An error has occurred: ${error}`);
             const emptyPatchArray: PatchArray = [];
             return emptyPatchArray;
         }
@@ -138,7 +135,7 @@ export namespace Parser {
 
             return patchObject;
         } catch (error: any) {
-            log({ message: `An error has occurred: ${error}`, color: red_bt });
+            logError(`An error has occurred: ${error}`);
             const returnValue: PatchObject = {
                 offset: BigInt(0),
                 previousValue: 0,

--- a/source/lib/patches/parser.wrappers.ts
+++ b/source/lib/patches/parser.wrappers.ts
@@ -1,8 +1,5 @@
-import Debug from '../auxiliary/debug.js';
-const { log } = Debug;
-
-import colorsCli from 'colors-cli';
-const { red_bt } = colorsCli;
+import Logger from '../auxiliary/logger.js';
+const { logError } = Logger;
 
 export namespace ParserWrappers {
     /**
@@ -24,7 +21,7 @@ export namespace ParserWrappers {
             const decimalString: number = parseInt(hexString, radix);
             return decimalString;
         } catch (error: any) {
-            log({ message: `An error has occurred: ${error}`, color: red_bt });
+            logError(`An error has occurred: ${error}`);
             return 0;
         }
     }
@@ -47,7 +44,7 @@ export namespace ParserWrappers {
             const value: bigint = BigInt('0x' + hexString);
             return value;
         } catch (error: any) {
-            log({ message: `An error has occurred: ${error}`, color: red_bt });
+            logError(`An error has occurred: ${error}`);
             return BigInt(0);
         }
     }
@@ -69,7 +66,7 @@ export namespace ParserWrappers {
             const patchData: Array<string> = fileData.split(/\r?\n/);
             return patchData;
         } catch (error: any) {
-            log({ message: `An error has occurred ${error}`, color: red_bt });
+            logError(`An error has occurred ${error}`);
             return new Array();
         }
     }

--- a/source/lib/patches/patches.ts
+++ b/source/lib/patches/patches.ts
@@ -1,8 +1,5 @@
-import Debug from '../auxiliary/debug.js';
-const { log } = Debug;
-
-import colorsCli from 'colors-cli';
-const { red_bt, white, yellow_bt } = colorsCli;
+import Logger from '../auxiliary/logger.js';
+const { logInfo, logWarn, logError } = Logger;
 
 
 import { join } from 'path';
@@ -48,7 +45,7 @@ export namespace Patches {
 
         const { runPatches } = configuration.options.patches;
         if (runPatches === false) {
-            log({ message: `Skipping running patches due to configuration`, color: white });
+            logInfo(`Skipping running patches due to configuration`);
             return;
         }
 
@@ -88,7 +85,7 @@ export namespace Patches {
                 if (patchOptions.skipWritingBinary === false)
                     await patchLargeFile({ filePath, patchData, options: patchOptions });
                 else
-                    log({ message: `Skipping writing binary file due to options`, color: white });
+                    logInfo(`Skipping writing binary file due to options`);
                 return;
             }
 
@@ -100,9 +97,9 @@ export namespace Patches {
             if (patchOptions.skipWritingBinary === false)
                 await writeBinaryFile({ filePath, buffer });
             else
-                log({ message: `Skipping writing binary file due to options`, color: white });
+                logInfo(`Skipping writing binary file due to options`);
         } catch (error) {
-            log({ message: `An error has ocurred running the patch ${error}`, color: red_bt });
+            logError(`An error has ocurred running the patch ${error}`);
         }
     }
 
@@ -123,15 +120,15 @@ export namespace Patches {
         const filePath: string = patch.fileNamePath;
 
         if (backupFiles === true) {
-            log({ message: `Backing up files due to backup files option`, color: white });
+            logInfo(`Backing up files due to backup files option`);
             await backupFile({ filePath });
         }
 
         if (fileSizeCheck === true) {
-            log({ message: `Checking file size due to file size check option`, color: white });
+            logInfo(`Checking file size due to file size check option`);
             const fileSize: number = await getFileSizeUsingPath({ filePath });
             if (fileSize <= fileSizeThreshold) {
-                log({ message: `File size check failed, file size is at or below the defined threshold of ${fileSizeThreshold}`, color: red_bt });
+                logError(`File size check failed, file size is at or below the defined threshold of ${fileSizeThreshold}`);
                 throw new Error(`File size check failed`);
             }
         }
@@ -160,7 +157,7 @@ export namespace Patches {
             const offsetNumber: number = Number(offset);
             const { forcePatch, unpatchMode, nullPatch, failOnUnexpectedPreviousValue, warnOnUnexpectedPreviousValue, skipWritePatch, allowOffsetOverflow, verifyPatch } = patchOptions;
             if (offsetNumber >= fileSize && allowOffsetOverflow !== true) {
-                log({ message: `Offset ${offset} exceeds file size ${fileSize}, skipping patch`, color: yellow_bt });
+                logWarn(`Offset ${offset} exceeds file size ${fileSize}, skipping patch`);
                 continue;
             }
             buffer = patchBuffer({


### PR DESCRIPTION
## Summary
- add a Logger utility with `logInfo`, `logSuccess`, `logWarn`, `logError`
- export logger in library index
- replace direct `colors-cli` usage across lib with Logger calls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686fed8e8ef08325adbf30ed154afaf7