### PR TITLE
Refactor async wrappers

### DIFF
--- a/source/lib/auxiliary/file.wrappers.ts
+++ b/source/lib/auxiliary/file.wrappers.ts
@@ -197,19 +197,16 @@ export namespace FileWrappers {
     export async function firstFilenameInFolder({ folderPath }:
         { folderPath: string }): Promise<string> {
 
-        return new Promise(function (resolve, reject) {
-            readdir(folderPath)
-                .then(function (filenames) {
-                    if (filenames.length === 0) {
-                        reject(new Error('No files found in directory'));
-                        return;
-                    }
-                    const completeFilePath: string = join(folderPath, filenames[0]);
-                    resolve(completeFilePath);
-                }).catch(function (error) {
-                    reject(error);
-                });
-        });
+        try {
+            const filenames: string[] = await readdir(folderPath);
+            if (filenames.length === 0) {
+                throw new Error('No files found in directory');
+            }
+            const completeFilePath: string = join(folderPath, filenames[0]);
+            return completeFilePath;
+        } catch (error) {
+            throw error;
+        }
     }
 }
 

--- a/source/lib/filedrops/packer.ts
+++ b/source/lib/filedrops/packer.ts
@@ -84,20 +84,24 @@ export namespace Packer {
      */
     export async function packFileWrapper({ destinationPath, sourcePath, options }:
         { destinationPath: string, sourcePath: string | string[], options: {} }): Promise<void> {
-        return new Promise(function (resolve, reject) {
-            logInfo(`Running pack file wrapper`);
-            const extractor: ZipStream = Seven.add(
-                destinationPath,
-                sourcePath,
-                options
-            );
-            extractor.on('end', function () {
-                resolve();
+        logInfo(`Running pack file wrapper`);
+        try {
+            await new Promise<void>(function (resolve, reject) {
+                const extractor: ZipStream = Seven.add(
+                    destinationPath,
+                    sourcePath,
+                    options
+                );
+                extractor.on('end', function () {
+                    resolve();
+                });
+                extractor.on('error', function (error) {
+                    reject(error);
+                });
             });
-            extractor.on('error', function (error) {
-                reject(error);
-            });
-        });
+        } catch (error) {
+            throw error;
+        }
     }
 
     /**
@@ -159,19 +163,23 @@ export namespace Packer {
      */
     export async function unpackFileWrapper({ archivePath, extractionPath, options }:
         { archivePath: string, extractionPath: string, options: {} }): Promise<void> {
-        return new Promise(function (resolve, reject) {
-            const extractor: ZipStream = Seven.extractFull(
-                archivePath,
-                extractionPath,
-                options
-            );
-            extractor.on('end', function () {
-                resolve();
+        try {
+            await new Promise<void>(function (resolve, reject) {
+                const extractor: ZipStream = Seven.extractFull(
+                    archivePath,
+                    extractionPath,
+                    options
+                );
+                extractor.on('end', function () {
+                    resolve();
+                });
+                extractor.on('error', function (error) {
+                    reject(error);
+                });
             });
-            extractor.on('error', function (error) {
-                reject(error);
-            });
-        });
+        } catch (error) {
+            throw error;
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- refactor `Packer.packFileWrapper` and `Packer.unpackFileWrapper` to be async and use `try`/`catch`
- simplify `FileWrappers.firstFilenameInFolder` with async/await

## Testing
- `npm run ts-build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871865288a88325ba3cfe65c329561d