### PR TITLE
Fix kill task escaping

### DIFF
--- a/source/lib/commands/commands.kill.ts
+++ b/source/lib/commands/commands.kill.ts
@@ -73,9 +73,10 @@ export namespace CommandsKill {
         { taskName: string }): Promise<string | null> {
 
         const command: string = TASKKILL_BIN;
+        const sanitizedTaskName: string = taskName.replace(/'/g, "'\\''");
         const parameters: string[] = IS_WINDOWS
             ? ['/f', '/im', taskName]
-            : ['-9', `$(pgrep -f \"${taskName}\")`];
+            : ['-9', `$(pgrep -f '${sanitizedTaskName}')`];
         const result: string | null = await runCommand({ command, parameters });
         return result;
     }

--- a/test/command.helpers.test.js
+++ b/test/command.helpers.test.js
@@ -155,7 +155,17 @@ describe('Command helpers - parameters', () => {
     await mods2.CommandsKill.killTask({ taskName: 'proc' });
     expect(mods2.Command.default.runCommand).toHaveBeenCalledWith({
       command: 'kill',
-      parameters: ['-9', '$(pgrep -f "proc")']
+      parameters: ['-9', '$(pgrep -f \'proc\')']
+    });
+  });
+
+  test('Kill command handles spaces', async () => {
+    const { CommandsKill, Command } = await loadModules('linux');
+    Command.default.runCommand.mockResolvedValue('');
+    await CommandsKill.killTask({ taskName: 'my proc' });
+    expect(Command.default.runCommand).toHaveBeenCalledWith({
+      command: 'kill',
+      parameters: ['-9', '$(pgrep -f \'my proc\')']
     });
   });
 });


### PR DESCRIPTION
## Summary
- escape single quotes when building Linux kill command
- update command helper tests for single-quoted pgrep call
- add test for process names with spaces

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687433363f948325ae63a9a4b26eb549