### PR TITLE
Fix newline in logToFile

### DIFF
--- a/source/lib/auxiliary/debug.logging.ts
+++ b/source/lib/auxiliary/debug.logging.ts
@@ -102,7 +102,7 @@ export namespace DebugLogging {
         try {
             const fileLogPath: string = getEnv({ envVarName: LOGGING_FILEPATH });
             const resolvedFileLogPath: string = getResolvedPath({ filePath: fileLogPath });
-            await appendFile(resolvedFileLogPath, message);
+            await appendFile(resolvedFileLogPath, message + '\n');
             return true;
         } catch {
             return false;

--- a/test/debug.test.js
+++ b/test/debug.test.js
@@ -45,7 +45,7 @@ describe('Debug utilities', () => {
     const rel = join(tmp, 'foo', '..', 'out.log');
     process.env[LOGGING_FILEPATH] = rel;
     await DebugLogging.logToFile({ message: 'hello' });
-    expect(appendFile).toHaveBeenCalledWith(resolve(rel), 'hello');
+    expect(appendFile).toHaveBeenCalledWith(resolve(rel), 'hello\n');
     fs.rmSync(tmp, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## Summary
- add newline when appending to log file
- update debug test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687436839fe48325933e2da043caf70b