### PR TITLE
Include task command in scheduler error

### DIFF
--- a/source/lib/commands/commands.taskschd.ts
+++ b/source/lib/commands/commands.taskschd.ts
@@ -66,7 +66,7 @@ export namespace CommandsTaskscheduler {
                     await stop({ taskName });
                     break;
                 default:
-                    throw new Error(`Unknown task scheduler function: ${taskName}`);
+                    throw new Error(`Unknown task scheduler function: ${functionName}`);
             }
 
         } catch (error) {


### PR DESCRIPTION
## Summary
- improve unknown task scheduler error to show command name

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687512c267708325b819027855038a94