### PR TITLE
Improve hexParse NaN handling and add test

### DIFF
--- a/source/lib/patches/parser.wrappers.ts
+++ b/source/lib/patches/parser.wrappers.ts
@@ -19,6 +19,10 @@ export namespace ParserWrappers {
         try {
             const radix: number = 16;
             const decimalString: number = parseInt(hexString, radix);
+            if (Number.isNaN(decimalString)) {
+                logError(`Invalid hexadecimal string: ${hexString}`);
+                return 0;
+            }
             return decimalString;
         } catch (error: any) {
             logError(`An error has occurred: ${error}`);

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -1,4 +1,4 @@
-import { Parser } from '../source/lib/patches/parser.ts';
+import { Parser, ParserWrappers } from '../source/lib/patches/parser.ts';
 
 describe('Parser.parsePatchFile', () => {
   test('parses patch data into objects', async () => {
@@ -37,5 +37,12 @@ describe('Parser.parsePatchFile', () => {
     expect(patches).toEqual([
       { offset: 0x00000000n, previousValue: 0x00, newValue: 0x01, byteLength: 1 }
     ]);
+  });
+});
+
+describe('ParserWrappers.hexParse', () => {
+  test('returns 0 for invalid hex strings', () => {
+    const value = ParserWrappers.hexParse({ hexString: 'g1' });
+    expect(value).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- improve error handling in `hexParse`
- test that `hexParse` returns 0 for invalid input

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68753adbaed48325b8ee3fa962e570a9