### PR TITLE
Remove isFileWritable check

### DIFF
--- a/source/lib/auxiliary/file.ts
+++ b/source/lib/auxiliary/file.ts
@@ -4,7 +4,7 @@ import BufferWrappers from '../patches/buffer.wrappers.js';
 const { createBuffer } = BufferWrappers;
 
 import FileWrappers from './file.wrappers.js';
-const { isFileReadable, isFileWritable, getFileSize } = FileWrappers;
+const { isFileReadable, getFileSize } = FileWrappers;
 
 import { FileHandle } from 'fs/promises';
 
@@ -128,8 +128,6 @@ export namespace File {
         let fileHandle: fs.FileHandle | undefined;
         try {
             logInfo(`Opening file path, ${filePath}, in write mode`);
-            if (!(await isFileWritable({ filePath })))
-                throw new Error(`File is not writable, is missing or corrupted`);
             const flags: string = 'w';
             fileHandle = await fs.open(filePath, flags);
             const bufferSize: number = await getFileSize({ fileHandle });

--- a/test/file.util.test.js
+++ b/test/file.util.test.js
@@ -23,12 +23,12 @@ describe('File utilities', () => {
   test('writeBinaryFile writes buffers and returns byte count', async () => {
     const dir = fs.mkdtempSync(join(os.tmpdir(), 'fileutil-'));
     const p = join(dir, 'out.bin');
-    fs.writeFileSync(p, '');
     const buf = Buffer.from([1, 2, 3]);
     const bytes = await File.writeBinaryFile({ filePath: p, buffer: buf });
     expect(bytes).toBe(3);
     const data = fs.readFileSync(p);
     expect(data.equals(buf)).toBe(true);
+    expect(fs.existsSync(p)).toBe(true);
     fs.rmSync(dir, { recursive: true, force: true });
   });
 


### PR DESCRIPTION
## Summary
- rely on `fs.open(filePath, 'w')` instead of checking `isFileWritable`
- update tests to confirm file creation when missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68753ae20fec8325bdb9f4e74f2003ed