### PR TITLE
Fix isDisabled and add test

### DIFF
--- a/source/lib/auxiliary/debug.ts
+++ b/source/lib/auxiliary/debug.ts
@@ -81,7 +81,9 @@ export namespace Debug {
         };
         return debugStatus;
     }
-    export function isDisabled(): boolean { return !isEnabled(); }
+    export function isDisabled(): boolean {
+        return !isEnabled().DEBUGGING;
+    }
 }
 
 export default Debug;

--- a/test/debug.test.js
+++ b/test/debug.test.js
@@ -40,6 +40,13 @@ describe('Debug utilities', () => {
     expect(Debug.isEnabled()).toEqual({ DEBUGGING: true, LOGGING: true });
   });
 
+  test('isDisabled reflects DEBUGGING state', () => {
+    Debug.disable();
+    expect(Debug.isDisabled()).toBe(true);
+    Debug.enable({});
+    expect(Debug.isDisabled()).toBe(false);
+  });
+
   test('logToFile resolves path and writes via appendFile', async () => {
     const tmp = fs.mkdtempSync(join(os.tmpdir(), 'debug-'));
     const rel = join(tmp, 'foo', '..', 'out.log');


### PR DESCRIPTION
## Summary
- fix `isDisabled` to negate the `DEBUGGING` status
- test that `isDisabled` accurately reflects debug state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68753af8d2108325b9848fc48807276d