### PR TITLE
Add spawn error listener

### DIFF
--- a/source/lib/commands/command.ts
+++ b/source/lib/commands/command.ts
@@ -48,6 +48,7 @@ export namespace Command {
 
         return new Promise(function (resolve, reject) {
             const childProcess: ChildProcessWithoutNullStreams = spawn(command, parameters, { shell: true });
+            childProcess.on('error', reject);
             let output: string = '';
             childProcess.stdout.on('data', function (data) {
                 output += data.toString();


### PR DESCRIPTION
## Summary
- reject `runCommandPromise` on spawn errors by listening to the `error` event

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68753afeb01c83258ade5e4ef2036659