### PR TITLE
Fix file size wrapper error handling

### DIFF
--- a/source/lib/auxiliary/file.wrappers.ts
+++ b/source/lib/auxiliary/file.wrappers.ts
@@ -24,10 +24,17 @@ export namespace FileWrappers {
      */
     export async function getFileSizeUsingPath({ filePath }:
         { filePath: string }): Promise<number> {
-        const fileHandle: FileHandle = await open(filePath);
-        const fileSize: number = await getFileSize({ fileHandle });
-        await fileHandle.close();
-        return fileSize;
+        let fileHandle: FileHandle | undefined;
+        try {
+            fileHandle = await open(filePath);
+            const fileSize: number = await getFileSize({ fileHandle });
+            return fileSize;
+        } catch {
+            return 0;
+        } finally {
+            if (fileHandle)
+                await fileHandle.close();
+        }
     }
 
     /**

--- a/test/file.util.test.js
+++ b/test/file.util.test.js
@@ -71,6 +71,11 @@ describe('File utilities', () => {
   test('firstFilenameInFolder rejects on failure', async () => {
     await expect(File.firstFilenameInFolder({ folderPath: '/missing' })).rejects.toThrow();
   });
+
+  test('getFileSizeUsingPath returns 0 for missing file', async () => {
+    const size = await File.getFileSizeUsingPath({ filePath: '/no/such/file' });
+    expect(size).toBe(0);
+  });
 });
 
 describe('File utilities failure mocks', () => {


### PR DESCRIPTION
## Summary
- prevent `getFileSizeUsingPath` from throwing when the file doesn't exist
- ensure the file handle is closed on errors
- test reading the file size of a missing file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68753b1f1ff883259f1ece1ad5aa1934