### PR TITLE
Handle big-endian in patchMultipleOffsets

### DIFF
--- a/source/lib/patches/patches.ts
+++ b/source/lib/patches/patches.ts
@@ -155,7 +155,7 @@ export namespace Patches {
             for (const patch of patchData) {
             const { offset, previousValue, newValue, byteLength } = patch;
             const offsetNumber: number = Number(offset);
-            const { forcePatch, unpatchMode, nullPatch, failOnUnexpectedPreviousValue, warnOnUnexpectedPreviousValue, skipWritePatch, allowOffsetOverflow, verifyPatch } = patchOptions;
+            const { forcePatch, unpatchMode, nullPatch, failOnUnexpectedPreviousValue, warnOnUnexpectedPreviousValue, skipWritePatch, allowOffsetOverflow, verifyPatch, bigEndian } = patchOptions;
             if (offsetNumber >= fileSize && allowOffsetOverflow !== true) {
                 logWarn(`Offset ${offset} exceeds file size ${fileSize}, skipping patch`);
                 continue;
@@ -170,7 +170,8 @@ export namespace Patches {
                     warnOnUnexpectedPreviousValue,
                     skipWritePatch,
                     allowOffsetOverflow,
-                    verifyPatch
+                    verifyPatch,
+                    bigEndian
                 }
             });
         }

--- a/test/patches.test.js
+++ b/test/patches.test.js
@@ -116,6 +116,28 @@ describe('Patches.runPatches', () => {
     expect(data.readBigUInt64LE(6)).toBe(0x1122334455667788n);
   });
 
+  test('patches big-endian multi-byte values', async () => {
+    const config = ConfigurationDefaults.getDefaultConfigurationObject();
+    fs.writeFileSync(testBinPath, Buffer.alloc(14));
+    config.patches = [
+      { name: 'multi', patchFilename: 'multi.patch', fileNamePath: testBinPath, enabled: true }
+    ];
+    const pOpts = config.options.patches;
+    pOpts.backupFiles = false;
+    pOpts.fileSizeCheck = false;
+    pOpts.skipWritingBinary = false;
+    pOpts.warnOnUnexpectedPreviousValue = false;
+    pOpts.failOnUnexpectedPreviousValue = false;
+    pOpts.bigEndian = true;
+    pOpts.runPatches = true;
+
+    await Patches.runPatches({ configuration: config });
+    const data = fs.readFileSync(testBinPath);
+    expect(data.readUInt16BE(0)).toBe(0x1234);
+    expect(data.readUInt32BE(2)).toBe(0x89abcdef);
+    expect(data.readBigUInt64BE(6)).toBe(0x1122334455667788n);
+  });
+
   test('patches offset at end of file', async () => {
     const config = ConfigurationDefaults.getDefaultConfigurationObject();
     fs.writeFileSync(testBinPath, Buffer.from([0x00, 0x01]));


### PR DESCRIPTION
## Summary
- forward `bigEndian` option when applying small-file patches
- verify big-endian behavior through `Patches.runPatches` tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d384261b08325995a7874a7e3dc7a