### PR TITLE
Handle buffer overflow when patching

### DIFF
--- a/source/lib/patches/buffer.ts
+++ b/source/lib/patches/buffer.ts
@@ -77,9 +77,14 @@ export namespace BufferUtils {
                 logWarn(`Offset ${offset} is negative, skipping patch`);
                 return buffer;
             }
-            if (allowOffsetOverflow !== true && offset + byteLength > buffer.length) {
-                logWarn(`Offset ${offset} with length ${byteLength} exceeds buffer size ${buffer.length}, skipping patch`);
-                return buffer;
+            if (offset + byteLength > buffer.length) {
+                if (allowOffsetOverflow !== true) {
+                    logWarn(`Offset ${offset} with length ${byteLength} exceeds buffer size ${buffer.length}, skipping patch`);
+                    return buffer;
+                }
+                const newBuffer = Buffer.alloc(offset + byteLength);
+                buffer.copy(newBuffer, 0, 0, buffer.length);
+                buffer = newBuffer;
             }
             const currentValue = readValue({ buffer, offset, byteLength, bigEndian });
 

--- a/test/buffer.test.js
+++ b/test/buffer.test.js
@@ -225,6 +225,29 @@ describe('BufferUtils.patchBuffer', () => {
     expect(Array.from(buf)).toEqual([0x00, 0x01]);
   });
 
+  test('expands buffer when overflow allowed', () => {
+    const buf = Buffer.from([0x00, 0x01]);
+    const patched = BufferUtils.patchBuffer({
+      buffer: buf,
+      offset: 2,
+      previousValue: 0x00,
+      newValue: 0xaa,
+      byteLength: 1,
+      options: {
+        forcePatch: false,
+        unpatchMode: false,
+        nullPatch: false,
+        failOnUnexpectedPreviousValue: false,
+        warnOnUnexpectedPreviousValue: false,
+        skipWritePatch: false,
+        allowOffsetOverflow: true
+      }
+    });
+    expect(Array.from(patched)).toEqual([0x00, 0x01, 0xaa]);
+    expect(patched.length).toBe(3);
+    expect(patched).not.toBe(buf);
+  });
+
   test('skips patch when offset is negative', () => {
     const buf = Buffer.from([0x00]);
     BufferUtils.patchBuffer({


### PR DESCRIPTION
## Summary
- resize buffers when `allowOffsetOverflow` permits patches past the end of the buffer
- test expanding a buffer when overflow patching is enabled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d38c554d48325b17077bff4d1b86b