### PR TITLE
Use pkill in killTask

### DIFF
--- a/source/lib/commands/command.ts
+++ b/source/lib/commands/command.ts
@@ -16,10 +16,10 @@ export namespace Command {
      * @returns Command output or null on failure
      * @since 0.0.1
      */
-    export async function runCommand({ command, parameters }:
-        { command: string, parameters: string[] }): Promise<string | null> {
+    export async function runCommand({ command, parameters, shell = true }:
+        { command: string, parameters: string[], shell?: boolean }): Promise<string | null> {
         try {
-            const result: string = await runCommandPromise({ command, parameters });
+            const result: string = await runCommandPromise({ command, parameters, shell });
             return result;
         } catch (error) {
             if (error && typeof error === 'object')
@@ -43,11 +43,11 @@ export namespace Command {
      * @returns Command output 
      * @since 0.0.1
      */
-    export async function runCommandPromise({ command, parameters }:
-        { command: string, parameters: string[] }): Promise<string> {
+    export async function runCommandPromise({ command, parameters, shell = true }:
+        { command: string, parameters: string[], shell?: boolean }): Promise<string> {
 
         return new Promise(function (resolve, reject) {
-            const childProcess: ChildProcessWithoutNullStreams = spawn(command, parameters, { shell: true });
+            const childProcess: ChildProcessWithoutNullStreams = spawn(command, parameters, { shell });
             childProcess.on('error', reject);
             let output: string = '';
             childProcess.stdout.on('data', function (data) {

--- a/source/lib/commands/commands.kill.ts
+++ b/source/lib/commands/commands.kill.ts
@@ -72,13 +72,17 @@ export namespace CommandsKill {
     export async function killTask({ taskName }:
         { taskName: string }): Promise<string | null> {
 
-        const command: string = TASKKILL_BIN;
-        const sanitizedTaskName: string = taskName.replace(/'/g, "'\\''");
-        const parameters: string[] = IS_WINDOWS
-            ? ['/f', '/im', taskName]
-            : ['-9', `$(pgrep -f '${sanitizedTaskName}')`];
-        const result: string | null = await runCommand({ command, parameters });
-        return result;
+        if (IS_WINDOWS) {
+            const command: string = TASKKILL_BIN;
+            const parameters: string[] = ['/f', '/im', taskName];
+            const result: string | null = await runCommand({ command, parameters });
+            return result;
+        } else {
+            const command: string = 'pkill';
+            const parameters: string[] = ['-9', '-f', taskName];
+            const result: string | null = await runCommand({ command, parameters, shell: false });
+            return result;
+        }
     }
 }
 

--- a/test/command.helpers.test.js
+++ b/test/command.helpers.test.js
@@ -154,8 +154,9 @@ describe('Command helpers - parameters', () => {
     mods2.Command.default.runCommand.mockResolvedValue('');
     await mods2.CommandsKill.killTask({ taskName: 'proc' });
     expect(mods2.Command.default.runCommand).toHaveBeenCalledWith({
-      command: 'kill',
-      parameters: ['-9', '$(pgrep -f \'proc\')']
+      command: 'pkill',
+      parameters: ['-9', '-f', 'proc'],
+      shell: false
     });
   });
 
@@ -164,8 +165,9 @@ describe('Command helpers - parameters', () => {
     Command.default.runCommand.mockResolvedValue('');
     await CommandsKill.killTask({ taskName: 'my proc' });
     expect(Command.default.runCommand).toHaveBeenCalledWith({
-      command: 'kill',
-      parameters: ['-9', '$(pgrep -f \'my proc\')']
+      command: 'pkill',
+      parameters: ['-9', '-f', 'my proc'],
+      shell: false
     });
   });
 });


### PR DESCRIPTION
## Summary
- support `shell` option in `runCommand`
- switch `killTask` to use `pkill -f`
- update kill command tests accordingly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e7590a1b8832590b6ccd3f27adbfe