### PR TITLE
Refactor predistPackage to return events-based promise

### DIFF
--- a/source/lib/build/predist.ts
+++ b/source/lib/build/predist.ts
@@ -20,23 +20,31 @@ export namespace Predist {
      * @since 0.0.1
      */
     export async function predistPackage(): Promise<void> {
-        try {
-            const seaArchiveName: string = `sea-archive.7z`;
+        return await new Promise<void>((resolve, reject) => {
+            try {
+                const seaArchiveName: string = `sea-archive.7z`;
 
-            debug.enable({ logging: false });
-            logInfo(`Packaging ${seaArchiveName}`);
-            const options: {} = {
-                method: PACKMETHOD,
-                $bin: SEVENZIPBIN_FILEPATH
-            };
-            const packageStream: ZipStream = Seven.add(`./sea/${seaArchiveName}`, `./sea/predist/*`, options);
-            packageStream.on('end', function () {
-                logSuccess(`Packaged ${seaArchiveName} successfully`);
-            });
+                debug.enable({ logging: false });
+                logInfo(`Packaging ${seaArchiveName}`);
+                const options: {} = {
+                    method: PACKMETHOD,
+                    $bin: SEVENZIPBIN_FILEPATH
+                };
+                const packageStream: ZipStream = Seven.add(`./sea/${seaArchiveName}`, `./sea/predist/*`, options);
+                packageStream.on('end', function () {
+                    logSuccess(`Packaged ${seaArchiveName} successfully`);
+                    resolve();
+                });
+                packageStream.on('error', function (error) {
+                    logError(`An error has ocurred while predist packaging ${error}`);
+                    reject(error);
+                });
 
-        } catch (error) {
-            logError(`An error has ocurred while predist packaging ${error}`);
-        }
+            } catch (error) {
+                logError(`An error has ocurred while predist packaging ${error}`);
+                reject(error);
+            }
+        });
     }
 }
 


### PR DESCRIPTION
## Summary
- return a promise from `Predist.predistPackage` that resolves when the 7zip stream emits `end` and rejects on `error`
- adjust the node-7z mock in build tests for controllable emitter
- add failure test case for `Predist.predistPackage`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bdb041fe88325b524c7033cdf879c