### PR TITLE
Handle buffer overflow expansion

### DIFF
--- a/source/lib/patches/buffer.ts
+++ b/source/lib/patches/buffer.ts
@@ -73,20 +73,21 @@ export namespace BufferUtils {
             bigEndian = false
         } = options;
         try {
+            let workingBuffer: Buffer = buffer;
             if (offset < 0) {
                 logWarn(`Offset ${offset} is negative, skipping patch`);
-                return buffer;
+                return workingBuffer;
             }
-            if (offset + byteLength > buffer.length) {
+            if (offset + byteLength > workingBuffer.length) {
                 if (allowOffsetOverflow !== true) {
-                    logWarn(`Offset ${offset} with length ${byteLength} exceeds buffer size ${buffer.length}, skipping patch`);
-                    return buffer;
+                    logWarn(`Offset ${offset} with length ${byteLength} exceeds buffer size ${workingBuffer.length}, skipping patch`);
+                    return workingBuffer;
                 }
-                const newBuffer = Buffer.alloc(offset + byteLength);
-                buffer.copy(newBuffer, 0, 0, buffer.length);
-                buffer = newBuffer;
+                const expanded = Buffer.alloc(offset + byteLength);
+                workingBuffer.copy(expanded, 0, 0, workingBuffer.length);
+                workingBuffer = expanded;
             }
-            const currentValue = readValue({ buffer, offset, byteLength, bigEndian });
+            const currentValue = readValue({ buffer: workingBuffer, offset, byteLength, bigEndian });
 
             validatePatchValues({
                 offset,
@@ -109,9 +110,9 @@ export namespace BufferUtils {
             });
 
             if (valueToWrite !== null) {
-                writeBuffer({ buffer, value: valueToWrite, offset, skipWritePatch, byteLength, bigEndian, verifyPatch });
+                writeBuffer({ buffer: workingBuffer, value: valueToWrite, offset, skipWritePatch, byteLength, bigEndian, verifyPatch });
             }
-            return buffer;
+            return workingBuffer;
         } catch (error: any) {
             logError(`An error has occurred: ${error}`);
             throw error;

--- a/test/buffer.test.js
+++ b/test/buffer.test.js
@@ -248,6 +248,29 @@ describe('BufferUtils.patchBuffer', () => {
     expect(patched).not.toBe(buf);
   });
 
+  test('expands buffer for multi-byte overflow patch', () => {
+    const buf = Buffer.from([0x00, 0x01]);
+    const patched = BufferUtils.patchBuffer({
+      buffer: buf,
+      offset: 1,
+      previousValue: 0x0001,
+      newValue: 0xaabb,
+      byteLength: 2,
+      options: {
+        forcePatch: false,
+        unpatchMode: false,
+        nullPatch: false,
+        failOnUnexpectedPreviousValue: false,
+        warnOnUnexpectedPreviousValue: false,
+        skipWritePatch: false,
+        allowOffsetOverflow: true
+      }
+    });
+    expect(Array.from(patched)).toEqual([0x00, 0xbb, 0xaa]);
+    expect(patched.length).toBe(3);
+    expect(patched).not.toBe(buf);
+  });
+
   test('skips patch when offset is negative', () => {
     const buf = Buffer.from([0x00]);
     BufferUtils.patchBuffer({


### PR DESCRIPTION
## Summary
- allow `patchBuffer` to grow the buffer when offset overflows
- test multi-byte patches when buffer expansion occurs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bdafa0cac8325b17520bafc7a6777