### PR TITLE
Rename IS_UBUNTU constant

### DIFF
--- a/source/lib/configuration/constants.ts
+++ b/source/lib/configuration/constants.ts
@@ -12,7 +12,8 @@ namespace Constants {
     /** Operating system checks */
     export const IS_WINDOWS: boolean = process.platform === 'win32';
     export const IS_MACOS: boolean = process.platform === 'darwin';
-    export const IS_UBUNTU: boolean = process.platform === 'linux';
+    export const IS_LINUX: boolean = process.platform === 'linux';
+    export const IS_UBUNTU: boolean = IS_LINUX; // alias for backward compatibility
 
     /** Task scheduler application binary name */
     export const TASKSCHD_BIN: string = IS_WINDOWS


### PR DESCRIPTION
## Summary
- rename `IS_UBUNTU` to `IS_LINUX`
- provide `IS_UBUNTU` alias for backward compatibility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d2c60ada4832582d49d5813376f0c