### PR TITLE
Fix parser delimiter

### DIFF
--- a/source/lib/patches/parser.ts
+++ b/source/lib/patches/parser.ts
@@ -101,8 +101,8 @@ export namespace Parser {
             const defaultPatchLength: number = 15;
             if (patchLineLength < defaultPatchLength)
                 throw new Error(`Patch at line ${index + 1} is invalid`);
-            const offsetValuesDelimiter: string = `: `;
-            const previousNewValueDelimiter: string = ' ';
+            const offsetValuesDelimiter = /:\s+/;
+            const previousNewValueDelimiter = ' ';
 
             const [offsetString, valuesString] = patchLine.split(offsetValuesDelimiter);
             const [previousValueString, newValueString] = valuesString.split(previousNewValueDelimiter);

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -38,6 +38,22 @@ describe('Parser.parsePatchFile', () => {
       { offset: 0x00000000n, previousValue: 0x00, newValue: 0x01, byteLength: 1 }
     ]);
   });
+
+  test('handles multiple spaces after colon', async () => {
+    const data = '00000000:   00 01';
+    const patches = await Parser.parsePatchFile({ fileData: data });
+    expect(patches).toEqual([
+      { offset: 0x00000000n, previousValue: 0x00, newValue: 0x01, byteLength: 1 }
+    ]);
+  });
+
+  test('handles tab after colon', async () => {
+    const data = '00000001:\t02 03';
+    const patches = await Parser.parsePatchFile({ fileData: data });
+    expect(patches).toEqual([
+      { offset: 0x00000001n, previousValue: 0x02, newValue: 0x03, byteLength: 1 }
+    ]);
+  });
 });
 
 describe('ParserWrappers.hexParse', () => {


### PR DESCRIPTION
## Summary
- allow `getPatchObject` to split on colon followed by any whitespace
- test patch parser with tabs and multiple spaces

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d2bf260408325b1e9185d92a3ca78