### PR TITLE
Add byte-length validation

### DIFF
--- a/source/lib/patches/parser.ts
+++ b/source/lib/patches/parser.ts
@@ -108,7 +108,10 @@ export namespace Parser {
             const [previousValueString, newValueString] = valuesString.split(previousNewValueDelimiter);
 
             const valueLength = Math.max(previousValueString.length, newValueString.length);
-            const byteLength = (valueLength / 2) as 1 | 2 | 4 | 8;
+            const byteLength = valueLength / 2;
+            if (![1, 2, 4, 8].includes(byteLength))
+                throw new Error(`Unsupported patch size ${byteLength}`);
+            const typedByteLength = byteLength as 1 | 2 | 4 | 8;
 
             let offset: bigint;
             if (offsetString.length > 8)
@@ -118,7 +121,7 @@ export namespace Parser {
 
             let previousValue: number | bigint;
             let newValue: number | bigint;
-            if (byteLength === 8) {
+            if (typedByteLength === 8) {
                 previousValue = hexParseBig({ hexString: previousValueString });
                 newValue = hexParseBig({ hexString: newValueString });
             } else {
@@ -130,19 +133,13 @@ export namespace Parser {
                 offset,
                 previousValue,
                 newValue,
-                byteLength
+                byteLength: typedByteLength
             };
 
             return patchObject;
         } catch (error: any) {
             logError(`An error has occurred: ${error}`);
-            const returnValue: PatchObject = {
-                offset: BigInt(0),
-                previousValue: 0,
-                newValue: 0,
-                byteLength: 1
-            };
-            return returnValue;
+            throw error;
         }
     }
 }

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -54,6 +54,12 @@ describe('Parser.parsePatchFile', () => {
       { offset: 0x00000001n, previousValue: 0x02, newValue: 0x03, byteLength: 1 }
     ]);
   });
+
+  test('returns empty array for unsupported patch size', async () => {
+    const data = '00000000: 000 01';
+    const patches = await Parser.parsePatchFile({ fileData: data });
+    expect(patches).toEqual([]);
+  });
 });
 
 describe('ParserWrappers.hexParse', () => {


### PR DESCRIPTION
## Summary
- validate computed byte length in patch parser
- propagate parser errors
- test unsupported byte length case

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d340984108325919f15b3dc80a748