### PR TITLE
feat: merge configuration with defaults

### DIFF
--- a/source/lib/configuration/configuration.ts
+++ b/source/lib/configuration/configuration.ts
@@ -23,6 +23,18 @@ export * from './configuration.defaults.js';
 export * from './configuration.types.js';
 
 export namespace Configuration {
+    function mergeWithDefaults(defaultObj: any, providedObj: any): any {
+        const result: any = Array.isArray(defaultObj) ? [...defaultObj] : { ...defaultObj };
+        if (!providedObj)
+            return result;
+        for (const [key, value] of Object.entries(providedObj)) {
+            if (value && typeof value === 'object' && !Array.isArray(value))
+                result[key] = mergeWithDefaults(defaultObj[key], value);
+            else
+                result[key] = value;
+        }
+        return result;
+    }
 
     /**
      * Read configuration file from a path
@@ -59,7 +71,9 @@ export namespace Configuration {
             else
                 logSuccess(`Configuration file read successfully`);
             const configObject: ConfigurationObject = JSON.parse(fileData);
-            return configObject;
+            const defaultConfig: ConfigurationObject = getDefaultConfigurationObject();
+            const mergedConfig: ConfigurationObject = mergeWithDefaults(defaultConfig, configObject);
+            return mergedConfig;
         } catch (error: any) {
             logError(`An error has occurred: ${error}`);
             const emptyConfig: ConfigurationObject = getDefaultConfigurationObject();

--- a/test/configuration.test.js
+++ b/test/configuration.test.js
@@ -20,6 +20,21 @@ describe('Configuration.readConfigurationFile', () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  test('merges configuration with defaults for missing keys', async () => {
+    const dir = fs.mkdtempSync(join(os.tmpdir(), 'cfg-'));
+    const filePath = join(dir, 'config.json');
+    const partialConfig = { options: { general: { debug: false } } };
+    fs.writeFileSync(filePath, JSON.stringify(partialConfig), 'utf-8');
+
+    const { Configuration } = await import('../source/lib/configuration/configuration.ts');
+    const result = await Configuration.readConfigurationFile({ filePath });
+
+    const expected = ConfigurationDefaults.getDefaultConfigurationObject();
+    expected.options.general.debug = false;
+    expect(result).toEqual(expected);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   test('returns defaults when file not readable', async () => {
     jest.resetModules();
     jest.unstable_mockModule('../source/lib/auxiliary/file.wrappers.ts', () => ({


### PR DESCRIPTION
## Summary
- merge configuration file contents with default configuration
- add unit test ensuring missing config keys are filled

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_688dc83e502883258442f06b0d534cf3