### PR TITLE
style: fix indentation in patchMultipleOffsets

### DIFF
--- a/source/lib/patches/patches.ts
+++ b/source/lib/patches/patches.ts
@@ -152,7 +152,7 @@ export namespace Patches {
 
         let buffer: Buffer = fileDataBuffer;
         const fileSize: number = buffer.length;
-            for (const patch of patchData) {
+        for (const patch of patchData) {
             const { offset, previousValue, newValue, byteLength } = patch;
             const offsetNumber: number = Number(offset);
             const { forcePatch, unpatchMode, nullPatch, failOnUnexpectedPreviousValue, warnOnUnexpectedPreviousValue, skipWritePatch, allowOffsetOverflow, verifyPatch, bigEndian } = patchOptions;


### PR DESCRIPTION
## Summary
- align `for` loop indentation in `patchMultipleOffsets`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688dc86bbeb083258d7391a5d2797193