### PR TITLE
Ensure file handles closed on stat failure

### DIFF
--- a/test/buffer.stat.failure.test.js
+++ b/test/buffer.stat.failure.test.js
@@ -1,0 +1,29 @@
+import { jest } from '@jest/globals';
+
+describe('BufferUtils.patchLargeFile', () => {
+  test('closes handle when stat fails', async () => {
+    const closeMock = jest.fn().mockResolvedValue(undefined);
+    jest.unstable_mockModule('fs/promises', async () => {
+      const actual = await jest.requireActual('fs/promises');
+      return {
+        ...actual,
+        open: jest.fn(async () => ({
+          stat: jest.fn().mockRejectedValue(new Error('stat failure')),
+          close: closeMock
+        }))
+      };
+    });
+    const { BufferUtils } = await import('../source/lib/patches/buffer.ts');
+    const opts = {
+      forcePatch: false,
+      unpatchMode: false,
+      nullPatch: false,
+      failOnUnexpectedPreviousValue: false,
+      warnOnUnexpectedPreviousValue: false,
+      skipWritePatch: false,
+      allowOffsetOverflow: false
+    };
+    await expect(BufferUtils.patchLargeFile({ filePath: 'dummy', patchData: [], options: opts })).rejects.toThrow('stat failure');
+    expect(closeMock).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- guard file handle cleanup in `patchLargeFile` by opening and statting inside a try block and closing only when the handle exists
- add regression test that mocks `fs/promises` to simulate `stat` failure and confirm the handle is closed

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689b93b7a7f483259f597450c7dfdac3