### PR TITLE
Handle binary buffers directly during encryption

### DIFF
--- a/source/lib/filedrops/crypt.ts
+++ b/source/lib/filedrops/crypt.ts
@@ -27,7 +27,6 @@ const {
     CRYPTO_KEYLENGTH,
     CRYPTO_PREFIX,
     //CRYPTO_FORMAT,
-    CRYPTO_ENCODING,
     //CRYPTO_ENCODING_DECRYPT,
     //CRYPTO_PREFIX_ENCODING,
     //CRYPTO_PREFIX_BYTES,
@@ -55,7 +54,7 @@ export namespace Encryption {
         { filePath?: string | undefined, buffer?: Buffer | undefined, key: string }): Promise<Buffer> {
 
         try {
-            let fileData: Buffer | string;
+            let fileData: Buffer;
 
             if (filePath && typeof filePath !== 'undefined' && typeof filePath === 'string') {
                 const filename: string = getFilename({ filePath });
@@ -71,8 +70,6 @@ export namespace Encryption {
                 }
             }
 
-            fileData = fileData.toString(CRYPTO_ENCODING);
-
             const salt: Buffer = randomBytes(CRYPTO_SALT_RANDOMBYTES);
             const iv: BinaryLike = randomBytes(CRYPTO_IV_RANDOMBYTES);
             const algorithm: CipherGCMTypes = CRYPTO_ALG;
@@ -84,7 +81,7 @@ export namespace Encryption {
             logInfo(`Encrypting data`);
 
             const encryptedData: Buffer = Buffer.concat([
-                Buffer.from(cipher.update(fileData, CRYPTO_ENCODING)),
+                cipher.update(fileData),
                 cipher.final()
             ]);
 

--- a/test/crypt.test.js
+++ b/test/crypt.test.js
@@ -1,4 +1,5 @@
 import { jest } from '@jest/globals';
+import { randomBytes } from 'crypto';
 
 jest.unstable_mockModule('../source/lib/auxiliary/file.js', () => ({
   default: {
@@ -23,6 +24,14 @@ describe('Encryption.encryptFile and decryptFile', () => {
   test('roundtrips buffer data', async () => {
     const data = Buffer.from('secret');
     const key = 'pass';
+    const encrypted = await Crypt.encryptFile({ buffer: data, key });
+    const decrypted = await Crypt.decryptFile({ buffer: encrypted, key });
+    expect(decrypted.equals(data)).toBe(true);
+  });
+
+  test('roundtrips binary data', async () => {
+    const data = randomBytes(256);
+    const key = 'bin';
     const encrypted = await Crypt.encryptFile({ buffer: data, key });
     const decrypted = await Crypt.decryptFile({ buffer: encrypted, key });
     expect(decrypted.equals(data)).toBe(true);


### PR DESCRIPTION
## Summary
- Pass buffers directly to the cipher in `crypt` to avoid encoding conversions
- Test round-trip encryption/decryption of random binary data

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689bdc475e6c8325bac5b6ae792835fc