### PR TITLE
feat: allow deleting absent folder

### DIFF
--- a/source/lib/auxiliary/file.wrappers.ts
+++ b/source/lib/auxiliary/file.wrappers.ts
@@ -207,8 +207,19 @@ export namespace FileWrappers {
         { folderPath: string }): Promise<void> {
 
         try {
-            await rm(folderPath, { recursive: true });
-            logInfo(`Deleted folder: ${folderPath}`);
+            let existed: boolean = true;
+            try {
+                await access(folderPath);
+            } catch {
+                existed = false;
+            }
+
+            await rm(folderPath, { recursive: true, force: true });
+
+            if (existed)
+                logInfo(`Removed folder: ${folderPath}`);
+            else
+                logInfo(`Folder already absent: ${folderPath}`);
         } catch (error) {
             logError(`Failed to delete folder: ${error}`);
         }

--- a/test/file.util.test.js
+++ b/test/file.util.test.js
@@ -97,6 +97,21 @@ describe('File utilities', () => {
     const size = await File.getFileSizeUsingPath({ filePath: '/no/such/file' });
     expect(size).toBe(0);
   });
+
+  test('deleteFolder handles missing directory without error', async () => {
+    jest.resetModules();
+    const logInfo = jest.fn();
+    const logSuccess = jest.fn();
+    const logWarn = jest.fn();
+    const logError = jest.fn();
+    jest.unstable_mockModule('../source/lib/auxiliary/logger.ts', () => ({
+      default: { logInfo, logSuccess, logWarn, logError }
+    }));
+    const { File: MockFile } = await import('../source/lib/auxiliary/file.ts');
+    await MockFile.deleteFolder({ folderPath: '/no/such/dir' });
+    expect(logError).not.toHaveBeenCalled();
+    expect(logInfo).toHaveBeenCalledWith('Folder already absent: /no/such/dir');
+  });
 });
 
 describe('writeBinaryFile size logging', () => {


### PR DESCRIPTION
## Summary
- treat missing directories as successful deletions
- clarify deleteFolder log messages
- cover missing-folder deletion with tests

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689bdc45751883258988ce2231f64a9e