### PR TITLE
Improve command error handling

### DIFF
--- a/source/lib/commands/command.ts
+++ b/source/lib/commands/command.ts
@@ -22,11 +22,12 @@ export namespace Command {
             const result: string = await runCommandPromise({ command, parameters, shell });
             return result;
         } catch (error) {
-            if (error && typeof error === 'object')
+            if (error && typeof error === 'object') {
                 if (String(error).length > 2) {
-                    const errorMessage: string = String(error).replaceAll('\r\n', '')
+                    const errorMessage: string = String(error).replace(/\r?\n/g, '');
                     logError(`There was an error running a command: ${errorMessage}`);
                 }
+            }
             return null;
         }
     }

--- a/test/command.test.js
+++ b/test/command.test.js
@@ -1,0 +1,26 @@
+import { jest } from '@jest/globals';
+
+describe('Command.runCommand error handling', () => {
+  test('logs error when command fails', async () => {
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    const logError = jest.fn();
+    jest.unstable_mockModule('../source/lib/auxiliary/logger.js', () => ({
+      default: { logError }
+    }));
+
+    const Command = (await import('../source/lib/commands/command.js')).default;
+
+    const result = await Command.runCommand({
+      command: 'node',
+      parameters: ['-e', "console.error('line1\\r\\nline2'); process.exit(1)"],
+      shell: false
+    });
+
+    expect(result).toBeNull();
+    expect(logError).toHaveBeenCalledWith(
+      'There was an error running a command: Error: Command exited with code 1 and output: line1line2'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- use braces and regex when logging command failures
- add test ensuring errors are logged when command execution fails

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bdc41418483259a5dc51c0b41023d