### PR TITLE
fix: clarify admin privilege check message

### DIFF
--- a/source/lib/auxiliary/uac.ts
+++ b/source/lib/auxiliary/uac.ts
@@ -42,7 +42,7 @@ export namespace Uac {
         const isAdministrator: boolean = await isAdmin();
         const exitCode: number = 1;
         if (!isAdministrator) {
-            logError(`Exiting because user doesn't have administrator privileges'`);
+            logError(`Exiting because user doesn't have administrator privileges`);
             exit(exitCode);
         }
     }

--- a/test/uac.test.js
+++ b/test/uac.test.js
@@ -46,7 +46,7 @@ describe('Uac.adminCheck', () => {
     await Uac.adminCheck();
     expect(exitSpy).toHaveBeenCalledWith(1);
     expect(logFn).toHaveBeenCalledWith({
-      message: "Exiting because user doesn't have administrator privileges'",
+      message: "Exiting because user doesn't have administrator privileges",
       color: expect.any(Function)
     });
     exitSpy.mockRestore();


### PR DESCRIPTION
## Summary
- fix admin privilege error message by removing stray quote
- adjust tests to reflect updated log message

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bdfbe27c083259357e697cb53f832