### PR TITLE
chore: handle async logging

### DIFF
--- a/source/lib/auxiliary/debug.logging.ts
+++ b/source/lib/auxiliary/debug.logging.ts
@@ -77,7 +77,7 @@ export namespace DebugLogging {
         const loggingEnabled: boolean = getEnvBoolean({ envVarName: LOGGING });
         if (loggingEnabled === true && safeCalleeFunction !== 'logToFile') {
             const logMessage: string = `${safeCalleeFilename}::${safeCalleeFunction} ::: ${message}`;
-            logToFile({ message: logMessage });
+            void logToFile({ message: logMessage }).catch(() => {});
         }
 
         const debug: Debugger = DebugLib.default(`${safeCalleeFilename}::${safeCalleeFunction}`);


### PR DESCRIPTION
## Summary
- prevent unhandled rejections when writing to the debug log file

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689bdfa635d883258ac8bfc7d3c9640e