### PR TITLE
refactor: type log color callback

### DIFF
--- a/source/lib/auxiliary/debug.logging.ts
+++ b/source/lib/auxiliary/debug.logging.ts
@@ -59,7 +59,7 @@ export namespace DebugLogging {
      * @since 0.0.1
      */   
     export function log({ message, color }:
-        { message: string, color: Function }): void {
+        { message: string, color: (text: string) => string }): void {
 
         const debugDisabled: boolean = !(getEnvBoolean({ envVarName: DEBUGGING }));
         if (debugDisabled === true) return;


### PR DESCRIPTION
## Summary
- narrow debug logging `log` color argument to a typed `(text: string) => string`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bdfa1defc832583e45ce172efed74