### PR TITLE
feat: add streaming patch parser

### DIFF
--- a/config.json
+++ b/config.json
@@ -30,7 +30,8 @@
       "unpatchMode": false,
       "verifyPatch": true,
       "backupFiles": true,
-      "skipWritingBinary": false
+      "skipWritingBinary": false,
+      "streamingParser": false
     },
     "commands": {
       "runCommands": true

--- a/source/lib/configuration/configuration.defaults.ts
+++ b/source/lib/configuration/configuration.defaults.ts
@@ -48,6 +48,7 @@ export namespace ConfigurationDefaults {
                     verifyPatch: true,
                     backupFiles: true,
                     skipWritingBinary: false,
+                    streamingParser: false,
                 },
                 commands: {
                     runCommands: true

--- a/source/lib/configuration/configuration.types.ts
+++ b/source/lib/configuration/configuration.types.ts
@@ -28,6 +28,8 @@ export type ConfigurationObject = {
             verifyPatch: boolean,
             backupFiles: boolean,
             skipWritingBinary: boolean,
+            /** Use streaming parser for patch files */
+            streamingParser: boolean,
         },
         commands: {
             runCommands: boolean

--- a/source/lib/patches/patches.ts
+++ b/source/lib/patches/patches.ts
@@ -8,7 +8,7 @@ import File from '../auxiliary/file.js';
 const { backupFile, getFileSizeUsingPath, readBinaryFile, readPatchFile, writeBinaryFile } = File;
 
 import Parser from './parser.js';
-const { parsePatchFile } = Parser;
+const { parsePatchFile, parsePatchFileStream } = Parser;
 
 import BufferUtils from './buffer.js';
 const { patchBuffer, patchLargeFile } = BufferUtils;
@@ -75,8 +75,14 @@ export namespace Patches {
             const patchOptions: PatchOptionsObject = configuration.options.patches;
 
             await prepatchChecksAndRoutines({ patchOptions, patch });
-            const patchFileData: string = await readPatchFile({ filePath: join(PATCHES_BASEPATH, patch.patchFilename) });
-            const patchData: PatchArray = await parsePatchFile({ fileData: patchFileData });
+            const patchFilePath: string = join(PATCHES_BASEPATH, patch.patchFilename);
+            let patchData: PatchArray;
+            if (patchOptions.streamingParser === true)
+                patchData = await parsePatchFileStream({ filePath: patchFilePath });
+            else {
+                const patchFileData: string = await readPatchFile({ filePath: patchFilePath });
+                patchData = await parsePatchFile({ fileData: patchFileData });
+            }
             const filePath: string = patch.fileNamePath;
 
             const fileSize: number = await getFileSizeUsingPath({ filePath });

--- a/test/parser.stream.test.js
+++ b/test/parser.stream.test.js
@@ -1,0 +1,46 @@
+import { Parser } from '../source/lib/patches/parser.ts';
+import fs from 'fs';
+import { join } from 'path';
+
+const patchDir = join('patch_files');
+const largePatchPath = join(patchDir, 'large.patch');
+
+// Utility to create large patch file without holding full contents in memory
+function createLargePatchFile(lines) {
+  fs.mkdirSync(patchDir, { recursive: true });
+  const stream = fs.createWriteStream(largePatchPath);
+  for (let i = 0; i < lines; i++) {
+    const line = `${i.toString(16).padStart(8, '0')}: 00 01\n`;
+    stream.write(line);
+  }
+  return new Promise(resolve => stream.end(resolve));
+}
+
+describe('Parser.parsePatchFileStream memory usage', () => {
+  const lines = 500000; // ~10MB file
+
+  beforeAll(async () => {
+    await createLargePatchFile(lines);
+    global.gc?.();
+  });
+
+  afterAll(() => {
+    fs.rmSync(largePatchPath, { force: true });
+  });
+
+  test('streaming parser uses less memory than non-streaming', async () => {
+    const beforeStream = process.memoryUsage().heapUsed;
+    const streamPatches = await Parser.parsePatchFileStream({ filePath: largePatchPath });
+    expect(streamPatches.length).toBe(lines);
+    const streamUsage = process.memoryUsage().heapUsed - beforeStream;
+
+    global.gc?.();
+    const fileData = fs.readFileSync(largePatchPath, 'utf-8');
+    const before = process.memoryUsage().heapUsed;
+    const patches = await Parser.parsePatchFile({ fileData });
+    expect(patches.length).toBe(lines);
+    const nonStreamUsage = process.memoryUsage().heapUsed - before;
+
+    expect(streamUsage).toBeLessThan(nonStreamUsage);
+  });
+});

--- a/test/patches.test.js
+++ b/test/patches.test.js
@@ -55,6 +55,26 @@ describe('Patches.runPatches', () => {
     expect(data[0]).toBe(0xff);
   });
 
+  test('patches a binary file using streaming parser', async () => {
+    const config = ConfigurationDefaults.getDefaultConfigurationObject();
+    fs.writeFileSync(testBinPath, Buffer.from([0x00]));
+    config.patches = [
+      { name: 'test', patchFilename: 'test.patch', fileNamePath: testBinPath, enabled: true }
+    ];
+    const pOpts = config.options.patches;
+    pOpts.backupFiles = false;
+    pOpts.fileSizeCheck = false;
+    pOpts.skipWritingBinary = false;
+    pOpts.warnOnUnexpectedPreviousValue = false;
+    pOpts.failOnUnexpectedPreviousValue = false;
+    pOpts.runPatches = true;
+    pOpts.streamingParser = true;
+
+    await Patches.runPatches({ configuration: config });
+    const data = fs.readFileSync(testBinPath);
+    expect(data[0]).toBe(0xff);
+  });
+
   test('handles 64-bit offsets', async () => {
     const config = ConfigurationDefaults.getDefaultConfigurationObject();
     fs.writeFileSync(testBinPath, Buffer.from([0x00]));


### PR DESCRIPTION
## Summary
- add streaming patch file parser to keep memory usage low
- allow `runPatch` to use streaming parser via `streamingParser` option
- test streaming parser with large patch files to confirm bounded memory

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bf22fadf483258041a6be15c0fc43