### PR TITLE
feat: add command timeout

### DIFF
--- a/test/command.test.js
+++ b/test/command.test.js
@@ -24,3 +24,18 @@ describe('Command.runCommand error handling', () => {
     );
   });
 });
+
+describe('Command.runCommandPromise timeout handling', () => {
+  test('rejects when process exceeds timeout', async () => {
+    const Command = (await import('../source/lib/commands/command.js')).default;
+
+    await expect(
+      Command.runCommandPromise({
+        command: 'node',
+        parameters: ['-e', "setTimeout(() => {}, 1000);"] ,
+        timeoutMs: 100,
+        shell: false
+      })
+    ).rejects.toThrow('Command timed out');
+  });
+});


### PR DESCRIPTION
## Summary
- allow commands to specify optional timeout and default shell to false for security
- terminate spawned processes that exceed the timeout
- add tests for command timeout behaviour

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689bf225af988325a85be33008272865