### PR TITLE
feat: add typed deep merge utility

### DIFF
--- a/test/configuration.test.js
+++ b/test/configuration.test.js
@@ -68,6 +68,27 @@ describe('Configuration.readConfigurationFile', () => {
     expect(defaultObj.options.general.obj).toEqual({ a: 1 });
   });
 
+  test('merges arrays of objects', async () => {
+    const defaults = { patches: [{ name: 'a', enabled: true }] };
+    const provided = { patches: [{ enabled: false }, { name: 'b', enabled: true }] };
+    const { Configuration } = await import('../source/lib/configuration/configuration.ts');
+    const result = Configuration.mergeWithDefaults(defaults, provided);
+    expect(result).toEqual({
+      patches: [
+        { name: 'a', enabled: false },
+        { name: 'b', enabled: true }
+      ]
+    });
+  });
+
+  test('merges nested structures', async () => {
+    const defaults = { a: { b: { c: 1 } } };
+    const provided = { a: { b: { d: 2 } } };
+    const { Configuration } = await import('../source/lib/configuration/configuration.ts');
+    const result = Configuration.mergeWithDefaults(defaults, provided);
+    expect(result).toEqual({ a: { b: { c: 1, d: 2 } } });
+  });
+
   test('returns defaults when file not readable', async () => {
     jest.resetModules();
     jest.unstable_mockModule('../source/lib/auxiliary/file.wrappers.ts', () => ({


### PR DESCRIPTION
## Summary
- replace mergeWithDefaults with generic deep merge that preserves types
- add tests for merging arrays of objects and nested structures

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bf22151288325afff0740e21244eb