### PR TITLE
Skip comment lines in patches parser

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -282,6 +282,9 @@ The value fields may contain 2, 4, 8 or 16 hex digits
 (representing 1, 2, 4 or 8 bytes respectively). `patcherjs`
 will automatically use the correct width when applying
 the patch.
+
+Lines beginning with `#`, `//` or `;` are treated as comments
+and ignored when parsing.
 ### Creating .patch files
 
 You can create patch files by exporting patches from x64dbg or vbindiff applications.

--- a/source/lib/patches/parser.ts
+++ b/source/lib/patches/parser.ts
@@ -71,6 +71,8 @@ export namespace Parser {
                 const trimmed = line.trim();
                 if (trimmed.length === 0)
                     continue;
+                if (trimmed.startsWith('#') || trimmed.startsWith('//') || trimmed.startsWith(';'))
+                    continue;
                 const patchObject: PatchObject = getPatchObject({ patchLine: trimmed, index });
                 patches.push(patchObject);
                 index++;
@@ -105,6 +107,8 @@ export namespace Parser {
             for (const [index, patchLine] of patchData.entries()) {
                 const trimmed = patchLine.trim();
                 if (trimmed.length === 0)
+                    continue;
+                if (trimmed.startsWith('#') || trimmed.startsWith('//') || trimmed.startsWith(';'))
                     continue;
                 const patchObject: PatchObject = getPatchObject({ patchLine: trimmed, index })
                 patches.push(patchObject);

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -55,6 +55,21 @@ describe('Parser.parsePatchFile', () => {
     ]);
   });
 
+  test('skips comment lines', async () => {
+    const data = [
+      '# comment',
+      '// another comment',
+      '; yet another comment',
+      '00000000: 00 01',
+      '00000001: 02 03'
+    ].join('\n');
+    const patches = await Parser.parsePatchFile({ fileData: data });
+    expect(patches).toEqual([
+      { offset: 0x00000000n, previousValue: 0x00, newValue: 0x01, byteLength: 1 },
+      { offset: 0x00000001n, previousValue: 0x02, newValue: 0x03, byteLength: 1 }
+    ]);
+  });
+
   test('returns empty array for unsupported patch size', async () => {
     const data = '00000000: 000 01';
     const patches = await Parser.parsePatchFile({ fileData: data });


### PR DESCRIPTION
## Summary
- skip lines starting with `#`, `//` or `;` when parsing patch files
- document comment syntax in patch file format
- add tests to ensure comment lines are ignored

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bf6e5bcd883258ea5cf848e365dd7