### PR TITLE
Improve mergeWithDefaults array merging

### DIFF
--- a/source/lib/configuration/configuration.ts
+++ b/source/lib/configuration/configuration.ts
@@ -40,14 +40,15 @@ export namespace Configuration {
         if (defaultIsArray || providedIsArray) {
             const defaultArray: unknown[] = defaultIsArray ? (defaultObj as unknown[]) : [];
             const providedArray: unknown[] = providedIsArray ? (providedObj as unknown[]) : [];
-            const length = Math.max(defaultArray.length, providedArray.length);
-            const result: unknown[] = [];
-            for (let i = 0; i < length; i++) {
-                result[i] = mergeWithDefaults(
-                    defaultArray[i] as any,
-                    providedArray[i] as any
-                );
-            }
+            const result: unknown[] = defaultArray.map(item => mergeWithDefaults(item));
+            providedArray.forEach((item, index) => {
+                if (index < result.length && (isObject(item) || Array.isArray(item)))
+                    result[index] = mergeWithDefaults(result[index], item as any);
+                else if (index < result.length && result[index] === item)
+                    return;
+                else
+                    result.push(mergeWithDefaults(undefined, item as any));
+            });
             return result as T;
         }
 

--- a/test/configuration.test.js
+++ b/test/configuration.test.js
@@ -81,6 +81,27 @@ describe('Configuration.readConfigurationFile', () => {
     });
   });
 
+  test('concatenates primitive arrays without undefined entries', async () => {
+    const defaults = { nums: [1, 2] };
+    const provided = { nums: [3] };
+    const { Configuration } = await import('../source/lib/configuration/configuration.ts');
+    const result = Configuration.mergeWithDefaults(defaults, provided);
+    expect(result.nums).toEqual([1, 2, 3]);
+    expect(result.nums).not.toContain(undefined);
+  });
+
+  test('handles shorter provided arrays without undefined entries', async () => {
+    const defaults = { patches: [{ name: 'a', enabled: true }, { name: 'b', enabled: false }] };
+    const provided = { patches: [{ enabled: false }] };
+    const { Configuration } = await import('../source/lib/configuration/configuration.ts');
+    const result = Configuration.mergeWithDefaults(defaults, provided);
+    expect(result.patches).toEqual([
+      { name: 'a', enabled: false },
+      { name: 'b', enabled: false }
+    ]);
+    expect(result.patches).not.toContain(undefined);
+  });
+
   test('merges nested structures', async () => {
     const defaults = { a: { b: { c: 1 } } };
     const provided = { a: { b: { d: 2 } } };


### PR DESCRIPTION
## Summary
- Refactor `mergeWithDefaults` to merge arrays by cloning defaults, deep-merging objects and concatenating new items without introducing `undefined`
- Add tests for primitive array concatenation and handling of shorter provided arrays

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bf6e3ca648325a66c10d11dda6585