### PR TITLE
feat: introduce specialized errors

### DIFF
--- a/source/lib/auxiliary/file.ts
+++ b/source/lib/auxiliary/file.ts
@@ -11,6 +11,8 @@ import { FileHandle } from 'fs/promises';
 import Logger from './logger.js';
 const { logInfo, logSuccess, logWarn, logError } = Logger;
 
+import { FileIOError } from '../errors/index.js';
+
 export * from './file.wrappers.js';
 
 export namespace File {
@@ -40,7 +42,7 @@ export namespace File {
             logInfo(`Opening file path, ${filePath}, in read mode`);
             const cantReadFile: boolean = !(await isFileReadable({ filePath }));
             if (cantReadFile)
-                throw new Error(`File is not readable, is missing or corrupted`);
+                throw new FileIOError(`File is not readable, is missing or corrupted`);
             fileHandle = await fs.open(filePath);
             const bufferSize: number = await getFileSize({ fileHandle });
             if (bufferSize === 0)
@@ -85,7 +87,7 @@ export namespace File {
         try {
             logInfo(`Opening file path, ${filePath}, in read mode`);
             if (!(await isFileReadable({ filePath })))
-                throw new Error(`File is not readable, is missing or corrupted`);
+                throw new FileIOError(`File is not readable, is missing or corrupted`);
             fileHandle = await fs.open(filePath);
             logInfo('Getting file size');
             const bufferSize: number = await getFileSize({ fileHandle });

--- a/source/lib/commands/command.ts
+++ b/source/lib/commands/command.ts
@@ -3,6 +3,8 @@ import { spawn, ChildProcessWithoutNullStreams } from 'child_process';
 import Logger from '../auxiliary/logger.js';
 const { logError } = Logger;
 
+import { CommandError } from '../errors/index.js';
+
 export namespace Command { 
     /**
      * Run a command
@@ -67,7 +69,7 @@ export namespace Command {
                 timer = setTimeout(() => {
                     timedOut = true;
                     childProcess.kill();
-                    reject(new Error(`Command timed out after ${timeoutMs}ms`));
+                    reject(new CommandError(`Command timed out after ${timeoutMs}ms`));
                 }, timeoutMs);
             }
 
@@ -92,7 +94,7 @@ export namespace Command {
                 if (exitCode === 0)
                     resolve(output);
                 else
-                    reject(new Error(`Command exited with code ${exitCode} and output: ${output}`));
+                    reject(new CommandError(`Command exited with code ${exitCode} and output: ${output}`));
             });
         });
     }

--- a/source/lib/errors/index.ts
+++ b/source/lib/errors/index.ts
@@ -1,0 +1,22 @@
+export class PatchParseError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'PatchParseError';
+    }
+}
+
+export class FileIOError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'FileIOError';
+    }
+}
+
+export class CommandError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'CommandError';
+    }
+}
+
+export default { PatchParseError, FileIOError, CommandError };

--- a/source/lib/patches/parser.ts
+++ b/source/lib/patches/parser.ts
@@ -7,6 +7,8 @@ const { hexParse, hexParseBig, splitLines } = ParserWrappers;
 import Logger from '../auxiliary/logger.js';
 const { logInfo, logSuccess, logError } = Logger;
 
+import { PatchParseError } from '../errors/index.js';
+
 import {
     PatchArray,
     PatchObject
@@ -32,7 +34,7 @@ export namespace Parser {
         try {
             const dataLength: number = fileData.length;
             if (dataLength === 0)
-                throw new Error(`Patch file data is empty or corrupted`);
+                throw new PatchParseError(`Patch file data is empty or corrupted`);
             logInfo(`Splitting file lines`);
             let patchData: string[] = splitLines({ fileData });
             // remove empty lines that may appear due to trailing newlines
@@ -111,7 +113,7 @@ export namespace Parser {
             }
             const patchesPushed: number = patches.length;
             if (patchesPushed === 0)
-                throw new Error(`There were 0 patch objects pushed to the patches array`);
+                throw new PatchParseError(`There were 0 patch objects pushed to the patches array`);
             logSuccess(`There were ${patchesPushed} patch objects pushed`);
             return patches;
         } catch (error: any) {
@@ -139,7 +141,7 @@ export namespace Parser {
             const patchLineLength: number = patchLine.length;
             const defaultPatchLength: number = 15;
             if (patchLineLength < defaultPatchLength)
-                throw new Error(`Patch at line ${index + 1} is invalid`);
+                throw new PatchParseError(`Patch at line ${index + 1} is invalid`);
             const offsetValuesDelimiter = /:\s+/;
             const previousNewValueDelimiter = ' ';
 
@@ -149,7 +151,7 @@ export namespace Parser {
             const valueLength = Math.max(previousValueString.length, newValueString.length);
             const byteLength = valueLength / 2;
             if (![1, 2, 4, 8].includes(byteLength))
-                throw new Error(`Unsupported patch size ${byteLength}`);
+                throw new PatchParseError(`Unsupported patch size ${byteLength}`);
             const typedByteLength = byteLength as 1 | 2 | 4 | 8;
 
             let offset: bigint;

--- a/test/command.test.js
+++ b/test/command.test.js
@@ -20,7 +20,7 @@ describe('Command.runCommand error handling', () => {
 
     expect(result).toBeNull();
     expect(logError).toHaveBeenCalledWith(
-      'There was an error running a command: Error: Command exited with code 1 and output: line1line2'
+      'There was an error running a command: CommandError: Command exited with code 1 and output: line1line2'
     );
   });
 });
@@ -36,6 +36,6 @@ describe('Command.runCommandPromise timeout handling', () => {
         timeoutMs: 100,
         shell: false
       })
-    ).rejects.toThrow('Command timed out');
+    ).rejects.toMatchObject({ name: 'CommandError' });
   });
 });


### PR DESCRIPTION
## Summary
- add PatchParseError, FileIOError and CommandError classes
- use specialized errors in parser, file utilities and command runner
- adjust command tests for new error handling

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bf6e0626c83259fa865aebd37a657