### PR TITLE
Support environment variables in patch and filedrop paths

### DIFF
--- a/source/lib/auxiliary/path.ts
+++ b/source/lib/auxiliary/path.ts
@@ -1,0 +1,26 @@
+import Logger from './logger.js';
+const { logWarn } = Logger;
+
+export namespace Path {
+    /**
+     * Replace `${VAR}` tokens within a path string with environment variable values.
+     *
+     * @param params.path Path string potentially containing `${VAR}` tokens
+     * @example
+     * ```
+     * resolveEnvPath({ path: '${HOME}/file.txt' });
+     * ```
+     * @returns Resolved path with environment variables substituted
+     * @since 0.0.1
+     */
+    export function resolveEnvPath({ path }:{ path: string }): string {
+        return path.replace(/\$\{(.*?)\}/g, (_match: string, name: string): string => {
+            const value: string | undefined = process.env[name];
+            if (value === undefined)
+                logWarn(`Environment variable ${name} is not defined`);
+            return value ?? '';
+        });
+    }
+}
+
+export default Path;

--- a/source/lib/filedrops/filedrops.ts
+++ b/source/lib/filedrops/filedrops.ts
@@ -7,6 +7,9 @@ const { decryptFile } = Crypt;
 import File from '../auxiliary/file.js';
 const { backupFile, readBinaryFile, writeBinaryFile } = File;
 
+import Path from '../auxiliary/path.js';
+const { resolveEnvPath } = Path;
+
 import Logger from '../auxiliary/logger.js';
 const { logInfo, logError, logSuccess } = Logger;
 import { join } from 'path';
@@ -67,7 +70,8 @@ export namespace Filedrops {
                 fileData = await readBinaryFile({ filePath });
             if (isFiledropPacked === true)
                 fileData = await unpackFile({ buffer: fileData, password: filedrop.decryptKey });
-            await writeBinaryFile({ filePath: filedrop.fileNamePath, buffer: fileData });
+            const destinationPath: string = resolveEnvPath({ path: filedrop.fileNamePath });
+            await writeBinaryFile({ filePath: destinationPath, buffer: fileData });
             logSuccess(`File was dropped successfully`);
         } catch (error) {
             logError(`There was an error while dropping a file: ${error}`);
@@ -89,7 +93,7 @@ export namespace Filedrops {
     async function prefiledropChecksAndRoutines({ filedropOptions, filedrop }:
         { filedropOptions: FiledropsOptionsObject, filedrop: FiledropsObject }): Promise<void> {
         const { backupFiles } = filedropOptions;
-        const filePath: string = filedrop.fileNamePath;
+        const filePath: string = resolveEnvPath({ path: filedrop.fileNamePath });
         if (backupFiles === true) {
             logInfo(`Backing up files due to backup files option`);
             await backupFile({ filePath });

--- a/source/lib/patches/patches.ts
+++ b/source/lib/patches/patches.ts
@@ -7,6 +7,9 @@ import { join } from 'path';
 import File from '../auxiliary/file.js';
 const { backupFile, getFileSizeUsingPath, readBinaryFile, readPatchFile, writeBinaryFile } = File;
 
+import Path from '../auxiliary/path.js';
+const { resolveEnvPath } = Path;
+
 import Parser from './parser.js';
 const { parsePatchFile, parsePatchFileStream } = Parser;
 
@@ -83,7 +86,7 @@ export namespace Patches {
                 const patchFileData: string = await readPatchFile({ filePath: patchFilePath });
                 patchData = await parsePatchFile({ fileData: patchFileData });
             }
-            const filePath: string = patch.fileNamePath;
+            const filePath: string = resolveEnvPath({ path: patch.fileNamePath });
 
             const fileSize: number = await getFileSizeUsingPath({ filePath });
             const hasBigOffset: boolean = patchData.some(p => p.offset > 0xffffffffn);
@@ -123,7 +126,7 @@ export namespace Patches {
         { patchOptions: PatchOptionsObject, patch: PatchFileObject }): Promise<void> {
 
         const { backupFiles, fileSizeCheck, fileSizeThreshold } = patchOptions;
-        const filePath: string = patch.fileNamePath;
+        const filePath: string = resolveEnvPath({ path: patch.fileNamePath });
 
         if (backupFiles === true) {
             logInfo(`Backing up files due to backup files option`);

--- a/test/filedrops.test.js
+++ b/test/filedrops.test.js
@@ -1,5 +1,6 @@
 import { jest } from '@jest/globals';
 import { ConfigurationDefaults } from '../source/lib/configuration/configuration.defaults.ts';
+import { join } from 'path';
 
 jest.unstable_mockModule('../source/lib/filedrops/crypt.js', () => ({
   default: { decryptFile: jest.fn(async () => Buffer.from('decrypted')) }
@@ -68,5 +69,38 @@ describe('Filedrops.runFiledrops', () => {
     expect(File.default.writeBinaryFile).not.toHaveBeenCalled();
     expect(File.default.readBinaryFile).not.toHaveBeenCalled();
     expect(File.default.backupFile).not.toHaveBeenCalled();
+  });
+
+  test('expands HOME variable in destination path', async () => {
+    const config = ConfigurationDefaults.getDefaultConfigurationObject();
+    const dest = join(process.env.HOME, 'fd_home.bin');
+    config.filedrops = [
+      { name: 'd', fileDropName: 'f.bin', packedFileName: 'f.pack', fileNamePath: '${HOME}/fd_home.bin', decryptKey: '', enabled: true }
+    ];
+    const opts = config.options.filedrops;
+    opts.runFiledrops = true;
+    opts.isFiledropPacked = false;
+    opts.isFiledropCrypted = false;
+    opts.backupFiles = false;
+    await Filedrops.runFiledrops({ configuration: config });
+    expect(File.default.writeBinaryFile).toHaveBeenCalledWith({ filePath: dest, buffer: Buffer.from('binary') });
+  });
+
+  test('expands custom variable in destination path', async () => {
+    const destDir = join(process.cwd(), 'filedrop_env');
+    process.env.MY_DROP_PATH = destDir;
+    const dest = join(destDir, 'fd_custom.bin');
+    const config = ConfigurationDefaults.getDefaultConfigurationObject();
+    config.filedrops = [
+      { name: 'd', fileDropName: 'f.bin', packedFileName: 'f.pack', fileNamePath: '${MY_DROP_PATH}/fd_custom.bin', decryptKey: '', enabled: true }
+    ];
+    const opts = config.options.filedrops;
+    opts.runFiledrops = true;
+    opts.isFiledropPacked = false;
+    opts.isFiledropCrypted = false;
+    opts.backupFiles = false;
+    await Filedrops.runFiledrops({ configuration: config });
+    expect(File.default.writeBinaryFile).toHaveBeenCalledWith({ filePath: dest, buffer: Buffer.from('binary') });
+    delete process.env.MY_DROP_PATH;
   });
 });

--- a/test/patches.envpath.test.js
+++ b/test/patches.envpath.test.js
@@ -1,0 +1,58 @@
+import { Patches } from '../source/lib/patches/patches.ts';
+import { ConfigurationDefaults } from '../source/lib/configuration/configuration.defaults.ts';
+import fs from 'fs';
+import { join } from 'path';
+
+const patchDir = join('patch_files');
+const envPatchPath = join(patchDir, 'env.patch');
+
+beforeAll(() => {
+  fs.mkdirSync(patchDir, { recursive: true });
+  fs.writeFileSync(envPatchPath, '00000000: 00 ff\n');
+});
+
+afterAll(() => {
+  fs.rmSync(envPatchPath, { force: true });
+});
+
+function makeConfig(pathStr) {
+  const config = ConfigurationDefaults.getDefaultConfigurationObject();
+  config.patches = [
+    { name: 'env', patchFilename: 'env.patch', fileNamePath: pathStr, enabled: true }
+  ];
+  const pOpts = config.options.patches;
+  pOpts.backupFiles = false;
+  pOpts.fileSizeCheck = false;
+  pOpts.skipWritingBinary = false;
+  pOpts.warnOnUnexpectedPreviousValue = false;
+  pOpts.failOnUnexpectedPreviousValue = false;
+  pOpts.runPatches = true;
+  return config;
+}
+
+describe('Patches environment path resolution', () => {
+  test('expands HOME variable in fileNamePath', async () => {
+    const dest = join(process.env.HOME, 'patch_home.bin');
+    fs.writeFileSync(dest, Buffer.from([0x00]));
+    const config = makeConfig('${HOME}/patch_home.bin');
+    await Patches.runPatches({ configuration: config });
+    const data = fs.readFileSync(dest);
+    expect(data[0]).toBe(0xff);
+    fs.rmSync(dest, { force: true });
+  });
+
+  test('expands custom variable in fileNamePath', async () => {
+    const destDir = join(process.cwd(), 'env_dest');
+    const dest = join(destDir, 'patch_custom.bin');
+    fs.mkdirSync(destDir, { recursive: true });
+    fs.writeFileSync(dest, Buffer.from([0x00]));
+    process.env.MY_PATCH_PATH = destDir;
+    const config = makeConfig('${MY_PATCH_PATH}/patch_custom.bin');
+    await Patches.runPatches({ configuration: config });
+    const data = fs.readFileSync(dest);
+    expect(data[0]).toBe(0xff);
+    delete process.env.MY_PATCH_PATH;
+    fs.rmSync(dest, { force: true });
+    fs.rmSync(destDir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary
- add `resolveEnvPath` helper to expand `${VAR}` tokens
- use helper when resolving patch `fileNamePath` and filedrop destinations
- test `${HOME}` and custom env variable expansion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bf6e8726c83258848f514d14f7920