### PR TITLE
feat(commands): add timeout and output limits

### DIFF
--- a/source/lib/commands/commands.ts
+++ b/source/lib/commands/commands.ts
@@ -110,7 +110,8 @@ export namespace Commands {
         for (const command of commands)
             if (command.enabled === true) {
                 logInfo(`Running general command ${command.name}: ${command.command}`);
-                await runCommand({ command: command.command, parameters: [] });
+                const DEFAULT_TIMEOUT = 60_000; // 60 seconds
+                await runCommand({ command: command.command, parameters: [], timeout: DEFAULT_TIMEOUT });
             }
     }
 }

--- a/test/command.test.js
+++ b/test/command.test.js
@@ -20,7 +20,7 @@ describe('Command.runCommand error handling', () => {
 
     expect(result).toBeNull();
     expect(logError).toHaveBeenCalledWith(
-      'There was an error running a command: CommandError: Command exited with code 1 and output: line1line2'
+      'There was an error running a command: CommandError: Command exited with code 1. Stdout: , Stderr: line1line2'
     );
   });
 });
@@ -33,7 +33,7 @@ describe('Command.runCommandPromise timeout handling', () => {
       Command.runCommandPromise({
         command: 'node',
         parameters: ['-e', "setTimeout(() => {}, 1000);"] ,
-        timeoutMs: 100,
+        timeout: 100,
         shell: false
       })
     ).rejects.toMatchObject({ name: 'CommandError' });

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -54,7 +54,7 @@ describe('Commands.runCommandsGeneral', () => {
       { name: 'test', command: 'echo hi', enabled: true }
     ];
     await Commands.runCommandsGeneral({ configuration: config });
-    expect(Command.default.runCommand).toHaveBeenCalledWith({ command: 'echo hi', parameters: [] });
+    expect(Command.default.runCommand).toHaveBeenCalledWith({ command: 'echo hi', parameters: [], timeout: 60000 });
   });
 
   test('skips disabled general commands', async () => {


### PR DESCRIPTION
## Summary
- allow commands to specify timeout and per-stream max buffer size
- terminate spawned processes on timeout and capture stdout/stderr separately
- run general commands with 60s default timeout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bf91a9cc4832582e8d543fffff627