### PR TITLE
feat: add configurable logger

### DIFF
--- a/source/lib/auxiliary/logger.ts
+++ b/source/lib/auxiliary/logger.ts
@@ -1,23 +1,69 @@
 import colorsCli from 'colors-cli';
+import { appendFileSync } from 'fs';
+import { resolve } from 'path';
+
 import Debug from './debug.js';
 const { log } = Debug;
+
 const { white, green_bt, yellow_bt, red_bt } = colorsCli;
 
+type LogLevel = 'info' | 'warn' | 'error' | 'silent';
+
+interface LoggerConfig {
+    level: LogLevel;
+    filePath?: string;
+}
+
+const levelPriority: Record<LogLevel, number> = {
+    info: 0,
+    warn: 1,
+    error: 2,
+    silent: 3
+};
+
+let config: LoggerConfig = {
+    level: (process.env.LOG_LEVEL as LogLevel) || 'info',
+    filePath: process.env.LOG_FILEPATH
+};
+
+function shouldLog(level: LogLevel): boolean {
+    return levelPriority[level] >= levelPriority[config.level];
+}
+
+function writeToFile(message: string): void {
+    if (!config.filePath) return;
+    try {
+        appendFileSync(resolve(config.filePath), message + '\n');
+    } catch {
+        // ignore file write errors
+    }
+}
+
+function logMessage(level: LogLevel, message: string, color: (text: string) => string): void {
+    if (!shouldLog(level)) return;
+    log({ message, color });
+    writeToFile(message);
+}
+
 export namespace Logger {
+    export function setConfig(newConfig: Partial<LoggerConfig>): void {
+        config = { ...config, ...newConfig };
+    }
+
     export function logInfo(message: string): void {
-        log({ message, color: white });
+        logMessage('info', message, white);
     }
 
     export function logSuccess(message: string): void {
-        log({ message, color: green_bt });
+        logMessage('info', message, green_bt);
     }
 
     export function logWarn(message: string): void {
-        log({ message, color: yellow_bt });
+        logMessage('warn', message, yellow_bt);
     }
 
     export function logError(message: string): void {
-        log({ message, color: red_bt });
+        logMessage('error', message, red_bt);
     }
 }
 

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -1,0 +1,37 @@
+import fs from 'fs';
+import os from 'os';
+import { join } from 'path';
+
+let Logger;
+
+beforeAll(async () => {
+  ({ Logger } = await import('../source/lib/auxiliary/logger.ts'));
+});
+
+afterEach(() => {
+  Logger.setConfig({ level: 'info', filePath: undefined });
+});
+
+describe('Logger file output', () => {
+  test('writes messages to file when configured', () => {
+    const dir = fs.mkdtempSync(join(os.tmpdir(), 'logger-'));
+    const file = join(dir, 'out.log');
+    Logger.setConfig({ level: 'info', filePath: file });
+    Logger.logInfo('hello file');
+    const content = fs.readFileSync(file, 'utf8');
+    expect(content.trim()).toBe('hello file');
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('respects configured log level', () => {
+    const dir = fs.mkdtempSync(join(os.tmpdir(), 'logger-'));
+    const file = join(dir, 'out.log');
+    Logger.setConfig({ level: 'error', filePath: file });
+    Logger.logWarn('skip this');
+    expect(fs.existsSync(file)).toBe(false);
+    Logger.logError('boom');
+    const content = fs.readFileSync(file, 'utf8');
+    expect(content.trim()).toBe('boom');
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary
- extend logger with configurable level and optional file output
- add tests for logger file writing and level filtering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c85b8c61483259799239e4335974d