### PR TITLE
refactor service command platform mapping

### DIFF
--- a/source/lib/commands/commands.services.ts
+++ b/source/lib/commands/commands.services.ts
@@ -14,10 +14,7 @@ const {
     COMM_SERVICES_DISABLE,
     COMM_SERVICES_REMOVE,
     COMM_SERVICES_STOP,
-    SERVICE_BIN,
-    IS_WINDOWS,
-    IS_MACOS,
-    IS_LINUX
+    SERVICE_BIN
 } = Constants;
 
 export namespace CommandsServices {
@@ -100,13 +97,15 @@ export namespace CommandsServices {
         { serviceName: string }): Promise<string | null> {
 
         const command: string = SERVICE_BIN;
-        const parameters: string[] = IS_WINDOWS
-            ? ['stop', serviceName]
-            : IS_MACOS
-                ? ['stop', serviceName]
-                : IS_LINUX
-                    ? ['stop', serviceName]
-                    : ['stop', serviceName];
+        const parametersMap: { [key: string]: string[] } = {
+            win32: ['stop', serviceName],
+            darwin: ['stop', serviceName],
+            linux: ['stop', serviceName]
+        };
+        const parameters = parametersMap[process.platform];
+        if (!parameters) {
+            throw new Error(`Unsupported platform for stop: ${process.platform}`);
+        }
         const result: string | null = await runCommand({ command, parameters });
         return result;
     }
@@ -126,13 +125,15 @@ export namespace CommandsServices {
         { serviceName: string }): Promise<string | null> {
 
         const command: string = SERVICE_BIN;
-        const parameters: string[] = IS_WINDOWS
-            ? ['config', serviceName, 'start=', 'disabled']
-            : IS_MACOS
-                ? ['disable', serviceName]
-                : IS_LINUX
-                    ? ['disable', serviceName]
-                    : ['disable', serviceName];
+        const parametersMap: { [key: string]: string[] } = {
+            win32: ['config', serviceName, 'start=', 'disabled'],
+            darwin: ['disable', serviceName],
+            linux: ['disable', serviceName]
+        };
+        const parameters = parametersMap[process.platform];
+        if (!parameters) {
+            throw new Error(`Unsupported platform for disable: ${process.platform}`);
+        }
         const result: string | null = await runCommand({ command, parameters });
         return result;
     }
@@ -153,13 +154,15 @@ export namespace CommandsServices {
         { serviceName: string }): Promise<string | null> {
 
         const command: string = SERVICE_BIN;
-        const parameters: string[] = IS_WINDOWS
-            ? ['delete', serviceName]
-            : IS_MACOS
-                ? ['remove', serviceName]
-                : IS_LINUX
-                    ? ['disable', '--now', serviceName]
-                    : ['disable', '--now', serviceName];
+        const parametersMap: { [key: string]: string[] } = {
+            win32: ['delete', serviceName],
+            darwin: ['remove', serviceName],
+            linux: ['disable', '--now', serviceName]
+        };
+        const parameters = parametersMap[process.platform];
+        if (!parameters) {
+            throw new Error(`Unsupported platform for remove: ${process.platform}`);
+        }
         const result: string | null = await runCommand({ command, parameters });
         return result;
     }

--- a/source/lib/configuration/configuration.ts
+++ b/source/lib/configuration/configuration.ts
@@ -118,7 +118,7 @@ export namespace Configuration {
             else
                 logSuccess(`Configuration file read successfully`);
             const configObject: unknown = JSON.parse(fileData);
-            const validatedConfig: ConfigurationObject = validateConfiguration(configObject);
+            validateConfiguration(configObject);
             const defaultConfig: ConfigurationObject = getDefaultConfigurationObject();
             const mergedConfig = mergeWithDefaults<ConfigurationObject>(defaultConfig, configObject as DeepPartial<ConfigurationObject>);
             return mergedConfig;

--- a/test/command.helpers.test.js
+++ b/test/command.helpers.test.js
@@ -1,11 +1,18 @@
 import { jest } from '@jest/globals';
 
+const originalPlatform = process.platform;
+afterEach(() => {
+  Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+});
+
 async function loadModules(platform) {
   jest.resetModules();
   jest.clearAllMocks();
 
-  const windows = platform === 'win';
-  const mac = platform === 'mac';
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+
+  const windows = platform === 'win32';
+  const mac = platform === 'darwin';
   const constants = {
     COMM_TASKS_DELETE: 'delete',
     COMM_TASKS_STOP: 'stop',
@@ -38,7 +45,7 @@ async function loadModules(platform) {
 
 describe('Command helpers - parameters', () => {
   test('Taskscheduler remove/stop on Windows', async () => {
-    const { CommandsTaskscheduler, Command } = await loadModules('win');
+    const { CommandsTaskscheduler, Command } = await loadModules('win32');
     Command.default.runCommand.mockResolvedValue('');
     await CommandsTaskscheduler.remove({ taskName: 'task' });
     expect(Command.default.runCommand).toHaveBeenLastCalledWith({
@@ -53,7 +60,7 @@ describe('Command helpers - parameters', () => {
   });
 
   test('Taskscheduler remove/stop on macOS', async () => {
-    const { CommandsTaskscheduler, Command } = await loadModules('mac');
+    const { CommandsTaskscheduler, Command } = await loadModules('darwin');
     Command.default.runCommand.mockResolvedValue('');
     await CommandsTaskscheduler.remove({ taskName: 'task' });
     expect(Command.default.runCommand).toHaveBeenLastCalledWith({
@@ -83,7 +90,7 @@ describe('Command helpers - parameters', () => {
   });
 
   test('Services commands on Windows', async () => {
-    const { CommandsServices, Command } = await loadModules('win');
+    const { CommandsServices, Command } = await loadModules('win32');
     Command.default.runCommand.mockResolvedValue('');
     await CommandsServices.stop({ serviceName: 'svc' });
     expect(Command.default.runCommand).toHaveBeenLastCalledWith({
@@ -103,7 +110,7 @@ describe('Command helpers - parameters', () => {
   });
 
   test('Services commands on macOS', async () => {
-    const { CommandsServices, Command } = await loadModules('mac');
+    const { CommandsServices, Command } = await loadModules('darwin');
     Command.default.runCommand.mockResolvedValue('');
     await CommandsServices.stop({ serviceName: 'svc' });
     expect(Command.default.runCommand).toHaveBeenLastCalledWith({
@@ -143,7 +150,7 @@ describe('Command helpers - parameters', () => {
   });
 
   test('Kill command lines', async () => {
-    const { CommandsKill, Command } = await loadModules('win');
+    const { CommandsKill, Command } = await loadModules('win32');
     Command.default.runCommand.mockResolvedValue('');
     await CommandsKill.killTask({ taskName: 'proc' });
     expect(Command.default.runCommand).toHaveBeenCalledWith({
@@ -174,11 +181,11 @@ describe('Command helpers - parameters', () => {
 
 describe('Command helpers - error handling', () => {
   test('propagates runCommand rejections', async () => {
-    const { CommandsServices, Command } = await loadModules('win');
+    const { CommandsServices, Command } = await loadModules('win32');
     Command.default.runCommand.mockRejectedValue(new Error('fail'));
     await expect(CommandsServices.stop({ serviceName: 'svc' })).rejects.toThrow('fail');
 
-    const { CommandsTaskscheduler, Command: Cmd2 } = await loadModules('win');
+    const { CommandsTaskscheduler, Command: Cmd2 } = await loadModules('win32');
     Cmd2.default.runCommand.mockRejectedValue(new Error('nope'));
     await expect(CommandsTaskscheduler.remove({ taskName: 't' })).rejects.toThrow('nope');
 


### PR DESCRIPTION
## Summary
- refactor service stop/disable/remove to use platform-argument mapping and throw on unsupported platforms
- add tests stubbing `process.platform` for argument selection and error handling
- clean up unused variable in configuration

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689c9eb19a4c8325b649a09bee0f1be4