### PR TITLE
feat(logger): handle invalid log level and async writes

### DIFF
--- a/source/lib/configuration/configuration.ts
+++ b/source/lib/configuration/configuration.ts
@@ -118,7 +118,7 @@ export namespace Configuration {
             else
                 logSuccess(`Configuration file read successfully`);
             const configObject: unknown = JSON.parse(fileData);
-            const validatedConfig: ConfigurationObject = validateConfiguration(configObject);
+            validateConfiguration(configObject);
             const defaultConfig: ConfigurationObject = getDefaultConfigurationObject();
             const mergedConfig = mergeWithDefaults<ConfigurationObject>(defaultConfig, configObject as DeepPartial<ConfigurationObject>);
             return mergedConfig;

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -1,37 +1,55 @@
 import fs from 'fs';
 import os from 'os';
 import { join } from 'path';
+import { jest } from '@jest/globals';
 
-let Logger;
-
-beforeAll(async () => {
-  ({ Logger } = await import('../source/lib/auxiliary/logger.ts'));
-});
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 afterEach(() => {
-  Logger.setConfig({ level: 'info', filePath: undefined });
+  delete process.env.LOG_LEVEL;
 });
 
 describe('Logger file output', () => {
-  test('writes messages to file when configured', () => {
+  test('writes messages to file when configured', async () => {
+    jest.resetModules();
+    const { Logger } = await import('../source/lib/auxiliary/logger.ts');
     const dir = fs.mkdtempSync(join(os.tmpdir(), 'logger-'));
     const file = join(dir, 'out.log');
     Logger.setConfig({ level: 'info', filePath: file });
     Logger.logInfo('hello file');
-    const content = fs.readFileSync(file, 'utf8');
+    await delay(20);
+    const content = await fs.promises.readFile(file, 'utf8');
     expect(content.trim()).toBe('hello file');
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
-  test('respects configured log level', () => {
+  test('respects configured log level', async () => {
+    jest.resetModules();
+    const { Logger } = await import('../source/lib/auxiliary/logger.ts');
     const dir = fs.mkdtempSync(join(os.tmpdir(), 'logger-'));
     const file = join(dir, 'out.log');
     Logger.setConfig({ level: 'error', filePath: file });
     Logger.logWarn('skip this');
+    await delay(20);
     expect(fs.existsSync(file)).toBe(false);
     Logger.logError('boom');
-    const content = fs.readFileSync(file, 'utf8');
+    await delay(20);
+    const content = await fs.promises.readFile(file, 'utf8');
     expect(content.trim()).toBe('boom');
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('falls back to info for invalid LOG_LEVEL', async () => {
+    process.env.LOG_LEVEL = 'nope';
+    jest.resetModules();
+    const { Logger } = await import('../source/lib/auxiliary/logger.ts');
+    const dir = fs.mkdtempSync(join(os.tmpdir(), 'logger-'));
+    const file = join(dir, 'out.log');
+    Logger.setConfig({ filePath: file });
+    Logger.logInfo('invalid level');
+    await delay(20);
+    const content = await fs.promises.readFile(file, 'utf8');
+    expect(content.trim()).toBe('invalid level');
     fs.rmSync(dir, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## Summary
- default to `info` when `LOG_LEVEL` is invalid
- write log file output asynchronously
- add logger tests for async file writes and invalid `LOG_LEVEL`
- remove unused variable in configuration to satisfy tsc

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c9eab7960832597cff1197deb45d3