### PR TITLE
refactor parser to process lines

### DIFF
--- a/test/parser.stream.test.js
+++ b/test/parser.stream.test.js
@@ -16,6 +16,30 @@ function createLargePatchFile(lines) {
   return new Promise(resolve => stream.end(resolve));
 }
 
+describe('Parser.parsePatchFileStream parsing', () => {
+  test('handles comments and empty lines identically to parsePatchFile', async () => {
+    const data = [
+      '',
+      '# comment',
+      '',
+      '00000000: 00 01',
+      '',
+      '// another comment',
+      '',
+      '00000001: 02 03',
+      '; trailing comment',
+      '',
+    ].join('\n');
+    fs.mkdirSync(patchDir, { recursive: true });
+    const filePath = join(patchDir, 'stream-temp.patch');
+    fs.writeFileSync(filePath, data);
+    const streamPatches = await Parser.parsePatchFileStream({ filePath });
+    const filePatches = await Parser.parsePatchFile({ fileData: data });
+    fs.unlinkSync(filePath);
+    expect(streamPatches).toEqual(filePatches);
+  });
+});
+
 describe('Parser.parsePatchFileStream memory usage', () => {
   const lines = 500000; // ~10MB file
 


### PR DESCRIPTION
## Summary
- deduplicate patch line handling via new private `processLines`
- refactor `parsePatchFile` and `parsePatchFileStream` to reuse `processLines`
- test both parsers treat comments and blank lines the same

## Testing
- `npm test -- test/parser.test.js test/parser.stream.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689cac3b31c88325b805b71ea71d587a