### PR TITLE
Handle non-tty stdin in console wait

### DIFF
--- a/source/lib/auxiliary/console.ts
+++ b/source/lib/auxiliary/console.ts
@@ -12,7 +12,10 @@ export namespace Console {
      * @returns Nada
      * @since 0.0.1
      */
-    export async function waitForKeypress(): Promise<void> {
+    export async function waitForKeypress({ force = false }: { force?: boolean } = {}): Promise<void> {
+
+        if (!force && !process.stdin.isTTY)
+            return;
 
         const consoleIface: Interface = readline.createInterface({
             input: process.stdin,

--- a/source/lib/composites.ts
+++ b/source/lib/composites.ts
@@ -41,6 +41,7 @@ export namespace Patcher {
      * 
      * @param params.configFilePath Configuration file path
      * @param params.waitForExit Wait for keypress before exiting (default true)
+     * @param params.waitForExitOnNonTTY Wait even if stdin is not a TTY (default false)
      * @example
      * ```
      * runPatcher({ configFilePath, waitForExit: false });
@@ -50,10 +51,12 @@ export namespace Patcher {
      */
     export async function runPatcher({
         configFilePath = CONFIG_FILEPATH,
-        waitForExit = true
+        waitForExit = true,
+        waitForExitOnNonTTY = false
     }: {
         configFilePath?: string,
-        waitForExit?: boolean
+        waitForExit?: boolean,
+        waitForExitOnNonTTY?: boolean
     }): Promise<void> {
         let failed = false;
         try {
@@ -80,7 +83,7 @@ export namespace Patcher {
 
             if (waitForExit) {
                 logInfo(`Press any key to close application...`);
-                await waitForKeypress();
+                await waitForKeypress({ force: waitForExitOnNonTTY });
             }
         }
     }

--- a/test/composites.test.js
+++ b/test/composites.test.js
@@ -92,7 +92,7 @@ describe('Patcher.runPatcher', () => {
       Patches.default.runPatches.mock.invocationCallOrder[0]
     ];
     expect(order).toEqual(order.slice().sort((a, b) => a - b));
-    expect(Console.default.waitForKeypress).toHaveBeenCalled();
+    expect(Console.default.waitForKeypress).toHaveBeenCalledWith({ force: false });
   });
 
   test('skips waiting when waitForExit is false', async () => {

--- a/test/console.test.js
+++ b/test/console.test.js
@@ -1,0 +1,21 @@
+import { jest } from '@jest/globals';
+import readline from 'readline';
+
+let Console;
+
+beforeAll(async () => {
+  Console = (await import('../source/lib/auxiliary/console.ts')).default;
+});
+
+test('waitForKeypress resolves immediately when stdin is not a TTY', async () => {
+  const descriptor = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
+  Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+  const spy = jest.spyOn(readline, 'createInterface');
+
+  await expect(Console.waitForKeypress()).resolves.toBeUndefined();
+  expect(spy).not.toHaveBeenCalled();
+
+  if (descriptor)
+    Object.defineProperty(process.stdin, 'isTTY', descriptor);
+  spy.mockRestore();
+});


### PR DESCRIPTION
## Summary
- resolve waitForKeypress immediately when stdin is not a TTY
- add `waitForExitOnNonTTY` option to `Patcher.runPatcher` to force waiting
- add tests for non-TTY keypress behavior

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689cac04d4288325a75320726836c5db