### PR TITLE
refactor command execution

### DIFF
--- a/source/lib/commands/commands.kill.ts
+++ b/source/lib/commands/commands.kill.ts
@@ -1,4 +1,4 @@
-import Command from './command.js';
+import Command, { CommandResult } from './command.js';
 const { runCommand } = Command;
 
 import Logger from '../auxiliary/logger.js';
@@ -70,17 +70,17 @@ export namespace CommandsKill {
      * @since 0.0.1
      */
     export async function killTask({ taskName }:
-        { taskName: string }): Promise<string | null> {
+        { taskName: string }): Promise<CommandResult> {
 
         if (IS_WINDOWS) {
             const command: string = TASKKILL_BIN;
             const parameters: string[] = ['/f', '/im', taskName];
-            const result: string | null = await runCommand({ command, parameters });
+            const result: CommandResult = await runCommand({ command, parameters });
             return result;
         } else {
             const command: string = 'pkill';
             const parameters: string[] = ['-9', '-f', taskName];
-            const result: string | null = await runCommand({ command, parameters, shell: false });
+            const result: CommandResult = await runCommand({ command, parameters, shell: false });
             return result;
         }
     }

--- a/source/lib/commands/commands.services.ts
+++ b/source/lib/commands/commands.services.ts
@@ -1,4 +1,4 @@
-import Command from './command.js';
+import Command, { CommandResult } from './command.js';
 const { runCommand } = Command;
 
 import Logger from '../auxiliary/logger.js';
@@ -94,7 +94,7 @@ export namespace CommandsServices {
      * @since 0.0.1
      */
     export async function stop({ serviceName }:
-        { serviceName: string }): Promise<string | null> {
+        { serviceName: string }): Promise<CommandResult> {
 
         const command: string = SERVICE_BIN;
         const parametersMap: { [key: string]: string[] } = {
@@ -106,7 +106,7 @@ export namespace CommandsServices {
         if (!parameters) {
             throw new Error(`Unsupported platform for stop: ${process.platform}`);
         }
-        const result: string | null = await runCommand({ command, parameters });
+        const result: CommandResult = await runCommand({ command, parameters });
         return result;
     }
 
@@ -122,7 +122,7 @@ export namespace CommandsServices {
      * @since 0.0.1
      */
     export async function disable({ serviceName }:
-        { serviceName: string }): Promise<string | null> {
+        { serviceName: string }): Promise<CommandResult> {
 
         const command: string = SERVICE_BIN;
         const parametersMap: { [key: string]: string[] } = {
@@ -134,7 +134,7 @@ export namespace CommandsServices {
         if (!parameters) {
             throw new Error(`Unsupported platform for disable: ${process.platform}`);
         }
-        const result: string | null = await runCommand({ command, parameters });
+        const result: CommandResult = await runCommand({ command, parameters });
         return result;
     }
 
@@ -151,7 +151,7 @@ export namespace CommandsServices {
      * @since 0.0.1
      */
     export async function remove({ serviceName }:
-        { serviceName: string }): Promise<string | null> {
+        { serviceName: string }): Promise<CommandResult> {
 
         const command: string = SERVICE_BIN;
         const parametersMap: { [key: string]: string[] } = {
@@ -163,7 +163,7 @@ export namespace CommandsServices {
         if (!parameters) {
             throw new Error(`Unsupported platform for remove: ${process.platform}`);
         }
-        const result: string | null = await runCommand({ command, parameters });
+        const result: CommandResult = await runCommand({ command, parameters });
         return result;
     }
 }

--- a/source/lib/commands/commands.taskschd.ts
+++ b/source/lib/commands/commands.taskschd.ts
@@ -1,4 +1,4 @@
-import Command from './command.js';
+import Command, { CommandResult } from './command.js';
 const { runCommand } = Command;
 
 import Logger from '../auxiliary/logger.js';
@@ -87,7 +87,7 @@ export namespace CommandsTaskscheduler {
      * @since 0.0.1
      */
     export async function remove({ taskName }:
-        { taskName: string }): Promise<string | null> {
+        { taskName: string }): Promise<CommandResult> {
         const command: string = TASKSCHD_BIN;
         const parameters: string[] = IS_WINDOWS
             ? ['/delete', '/f', '/tn', taskName]
@@ -96,7 +96,7 @@ export namespace CommandsTaskscheduler {
                 : IS_LINUX
                     ? ['disable', '--now', taskName]
                     : ['disable', '--now', taskName];
-        const result: string | null = await runCommand({ command, parameters });
+        const result: CommandResult = await runCommand({ command, parameters });
         return result;
     }
 
@@ -112,7 +112,7 @@ export namespace CommandsTaskscheduler {
      * @since 0.0.1
      */
     export async function stop({ taskName }:
-        { taskName: string }): Promise<string | null> {
+        { taskName: string }): Promise<CommandResult> {
         const command: string = TASKSCHD_BIN;
         const parameters: string[] = IS_WINDOWS
             ? ['/end', '/tn', taskName]
@@ -121,7 +121,7 @@ export namespace CommandsTaskscheduler {
                 : IS_LINUX
                     ? ['stop', taskName]
                     : ['stop', taskName];
-        const result: string | null = await runCommand({ command, parameters });
+        const result: CommandResult = await runCommand({ command, parameters });
         return result;
     }
 }

--- a/source/lib/commands/commands.ts
+++ b/source/lib/commands/commands.ts
@@ -111,7 +111,12 @@ export namespace Commands {
             if (command.enabled === true) {
                 logInfo(`Running general command ${command.name}: ${command.command}`);
                 const DEFAULT_TIMEOUT = 60_000; // 60 seconds
-                await runCommand({ command: command.command, parameters: [], timeout: DEFAULT_TIMEOUT });
+                const { stdout, stderr, exitCode } = await runCommand({ command: command.command, parameters: [], timeout: DEFAULT_TIMEOUT });
+                if (stdout)
+                    logInfo(stdout);
+                if (stderr)
+                    logError(stderr);
+                logInfo(`Command exited with code ${exitCode}`);
             }
     }
 }

--- a/source/lib/errors/index.ts
+++ b/source/lib/errors/index.ts
@@ -12,10 +12,22 @@ export class FileIOError extends Error {
     }
 }
 
+export interface CommandErrorOptions {
+    stdout?: string;
+    stderr?: string;
+    exitCode?: number | null;
+}
+
 export class CommandError extends Error {
-    constructor(message: string) {
+    stdout: string;
+    stderr: string;
+    exitCode: number | null;
+    constructor(message: string, { stdout = '', stderr = '', exitCode = null }: CommandErrorOptions = {}) {
         super(message);
         this.name = 'CommandError';
+        this.stdout = stdout;
+        this.stderr = stderr;
+        this.exitCode = exitCode;
     }
 }
 

--- a/test/command.test.js
+++ b/test/command.test.js
@@ -12,15 +12,14 @@ describe('Command.runCommand error handling', () => {
 
     const Command = (await import('../source/lib/commands/command.js')).default;
 
-    const result = await Command.runCommand({
+    await expect(Command.runCommand({
       command: 'node',
       parameters: ['-e', "console.error('line1\\r\\nline2'); process.exit(1)"],
       shell: false
-    });
+    })).rejects.toMatchObject({ name: 'CommandError', exitCode: 1 });
 
-    expect(result).toBeNull();
     expect(logError).toHaveBeenCalledWith(
-      'There was an error running a command: CommandError: Command exited with code 1. Stdout: , Stderr: line1line2'
+      'There was an error running a command: Command exited with code 1'
     );
   });
 });

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -14,7 +14,7 @@ jest.unstable_mockModule('../source/lib/commands/commands.kill.js', () => ({
 }));
 
 jest.unstable_mockModule('../source/lib/commands/command.js', () => ({
-  default: { runCommand: jest.fn() }
+  default: { runCommand: jest.fn().mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 }) }
 }));
 
 let Commands;


### PR DESCRIPTION
## Summary
- refactor `runCommand` to return stdout, stderr, and exit code
- surface detailed output through `CommandError`
- update general command runner and tests for new command result structure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ce3279a788325bdc334f1873819ca