### PR TITLE
feat: expand env paths

### DIFF
--- a/source/lib/auxiliary/path.ts
+++ b/source/lib/auxiliary/path.ts
@@ -1,4 +1,5 @@
 import Logger from './logger.js';
+import os from 'os';
 const { logWarn } = Logger;
 
 export namespace Path {
@@ -14,12 +15,23 @@ export namespace Path {
      * @since 0.0.1
      */
     export function resolveEnvPath({ path }:{ path: string }): string {
-        return path.replace(/\$\{(.*?)\}/g, (_match: string, name: string): string => {
+        let resolvedPath: string = path.replace(/^~(?=$|[\\/])/, os.homedir());
+
+        resolvedPath = resolvedPath.replace(/\$\{(.*?)\}/g, (_match: string, name: string): string => {
             const value: string | undefined = process.env[name];
             if (value === undefined)
                 logWarn(`Environment variable ${name} is not defined`);
             return value ?? '';
         });
+
+        resolvedPath = resolvedPath.replace(/%([^%]+)%/g, (_match: string, name: string): string => {
+            const value: string | undefined = process.env[name];
+            if (value === undefined)
+                logWarn(`Environment variable ${name} is not defined`);
+            return value ?? '';
+        });
+
+        return resolvedPath;
     }
 }
 

--- a/test/patches.envpath.test.js
+++ b/test/patches.envpath.test.js
@@ -1,6 +1,7 @@
 import { Patches } from '../source/lib/patches/patches.ts';
 import { ConfigurationDefaults } from '../source/lib/configuration/configuration.defaults.ts';
 import fs from 'fs';
+import os from 'os';
 import { join } from 'path';
 
 const patchDir = join('patch_files');
@@ -52,6 +53,31 @@ describe('Patches environment path resolution', () => {
     const data = fs.readFileSync(dest);
     expect(data[0]).toBe(0xff);
     delete process.env.MY_PATCH_PATH;
+    fs.rmSync(dest, { force: true });
+    fs.rmSync(destDir, { recursive: true, force: true });
+  });
+
+  test('expands tilde in fileNamePath', async () => {
+    const dest = join(os.homedir(), 'patch_tilde.bin');
+    fs.writeFileSync(dest, Buffer.from([0x00]));
+    const config = makeConfig('~/patch_tilde.bin');
+    await Patches.runPatches({ configuration: config });
+    const data = fs.readFileSync(dest);
+    expect(data[0]).toBe(0xff);
+    fs.rmSync(dest, { force: true });
+  });
+
+  test('expands percent-style variable in fileNamePath', async () => {
+    const destDir = join(process.cwd(), 'env_dest_percent');
+    const dest = join(destDir, 'patch_percent.bin');
+    fs.mkdirSync(destDir, { recursive: true });
+    fs.writeFileSync(dest, Buffer.from([0x00]));
+    process.env.MY_PERCENT_PATH = destDir;
+    const config = makeConfig('%MY_PERCENT_PATH%/patch_percent.bin');
+    await Patches.runPatches({ configuration: config });
+    const data = fs.readFileSync(dest);
+    expect(data[0]).toBe(0xff);
+    delete process.env.MY_PERCENT_PATH;
     fs.rmSync(dest, { force: true });
     fs.rmSync(destDir, { recursive: true, force: true });
   });


### PR DESCRIPTION
## Summary
- expand `resolveEnvPath` to support `~` and Windows `%VAR%` placeholders
- test path resolution for `~` and `%VAR%` tokens

## Testing
- `npm test test/patches.envpath.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689ce2b1ec908325b3c010c1d827525a