### PR TITLE
feat: allow configurable buffer truncation

### DIFF
--- a/source/lib/patches/buffer.ts
+++ b/source/lib/patches/buffer.ts
@@ -392,16 +392,18 @@ export namespace BufferUtils {
      * @param params.buffer Buffer to truncate
      * @example
      * ```
-     * truncateBuffer({ buffer });
+     * truncateBuffer({ buffer, maxLength });
      * ```
+     * @param params.buffer Buffer to truncate
+     * @param params.maxLength Maximum length of buffer to return (default 200)
      * @returns Truncated buffer
      * @since 0.0.1
      */
-    export function truncateBuffer({ buffer }:
-        { buffer: Buffer }) {
-        if (buffer.length < 200)
+    export function truncateBuffer({ buffer, maxLength = 200 }:
+        { buffer: Buffer; maxLength?: number }) {
+        if (buffer.length <= maxLength)
             return buffer;
-        return buffer.subarray(0, 200);
+        return buffer.subarray(0, maxLength);
     }
 }
 

--- a/test/buffer.test.js
+++ b/test/buffer.test.js
@@ -504,9 +504,15 @@ describe('BufferUtils.patchLargeFile', () => {
 });
 
 describe('BufferUtils.truncateBuffer', () => {
-  test('buffers larger than 200 bytes are truncated', () => {
+  test('buffers larger than 200 bytes are truncated by default', () => {
     const buf = Buffer.alloc(250, 0xff);
     const truncated = BufferUtils.truncateBuffer({ buffer: buf });
     expect(truncated.length).toBe(200);
+  });
+
+  test('buffers are truncated to a custom maxLength', () => {
+    const buf = Buffer.alloc(250, 0xff);
+    const truncated = BufferUtils.truncateBuffer({ buffer: buf, maxLength: 150 });
+    expect(truncated.length).toBe(150);
   });
 });


### PR DESCRIPTION
## Summary
- allow `truncateBuffer` to accept a custom `maxLength`
- test truncation with default and custom lengths

## Testing
- `npm test -- test/buffer.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689ce2a9c8f883259edd91b6b2e66458