### PR TITLE
refactor parser to unify file and stream parsing

### DIFF
--- a/source/lib/patches/patches.ts
+++ b/source/lib/patches/patches.ts
@@ -5,13 +5,13 @@ const { logInfo, logWarn, logError } = Logger;
 import { join } from 'path';
 
 import File from '../auxiliary/file.js';
-const { backupFile, getFileSizeUsingPath, readBinaryFile, readPatchFile, writeBinaryFile } = File;
+const { backupFile, getFileSizeUsingPath, readBinaryFile, writeBinaryFile } = File;
 
 import Path from '../auxiliary/path.js';
 const { resolveEnvPath } = Path;
 
 import Parser from './parser.js';
-const { parsePatchFile, parsePatchFileStream } = Parser;
+const { parsePatchFile } = Parser;
 
 import BufferUtils from './buffer.js';
 const { patchBuffer, patchLargeFile } = BufferUtils;
@@ -79,13 +79,7 @@ export namespace Patches {
 
             await prepatchChecksAndRoutines({ patchOptions, patch });
             const patchFilePath: string = join(PATCHES_BASEPATH, patch.patchFilename);
-            let patchData: PatchArray;
-            if (patchOptions.streamingParser === true)
-                patchData = await parsePatchFileStream({ filePath: patchFilePath });
-            else {
-                const patchFileData: string = await readPatchFile({ filePath: patchFilePath });
-                patchData = await parsePatchFile({ fileData: patchFileData });
-            }
+            const patchData: PatchArray = await parsePatchFile({ filePath: patchFilePath, useStream: patchOptions.streamingParser });
             const filePath: string = resolveEnvPath({ path: patch.fileNamePath });
 
             const fileSize: number = await getFileSizeUsingPath({ filePath });

--- a/test/parser.stream.test.js
+++ b/test/parser.stream.test.js
@@ -16,7 +16,7 @@ function createLargePatchFile(lines) {
   return new Promise(resolve => stream.end(resolve));
 }
 
-describe('Parser.parsePatchFileStream parsing', () => {
+describe('Parser.parsePatchFile streaming parsing', () => {
   test('handles comments and empty lines identically to parsePatchFile', async () => {
     const data = [
       '',
@@ -33,14 +33,14 @@ describe('Parser.parsePatchFileStream parsing', () => {
     fs.mkdirSync(patchDir, { recursive: true });
     const filePath = join(patchDir, 'stream-temp.patch');
     fs.writeFileSync(filePath, data);
-    const streamPatches = await Parser.parsePatchFileStream({ filePath });
+    const streamPatches = await Parser.parsePatchFile({ filePath, useStream: true });
     const filePatches = await Parser.parsePatchFile({ fileData: data });
     fs.unlinkSync(filePath);
     expect(streamPatches).toEqual(filePatches);
   });
 });
 
-describe('Parser.parsePatchFileStream memory usage', () => {
+describe('Parser.parsePatchFile streaming memory usage', () => {
   const lines = 500000; // ~10MB file
 
   beforeAll(async () => {
@@ -54,7 +54,7 @@ describe('Parser.parsePatchFileStream memory usage', () => {
 
   test('streaming parser uses less memory than non-streaming', async () => {
     const beforeStream = process.memoryUsage().heapUsed;
-    const streamPatches = await Parser.parsePatchFileStream({ filePath: largePatchPath });
+    const streamPatches = await Parser.parsePatchFile({ filePath: largePatchPath, useStream: true });
     expect(streamPatches.length).toBe(lines);
     const streamUsage = process.memoryUsage().heapUsed - beforeStream;
 

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -97,7 +97,7 @@ describe('Parser.parsePatchFile', () => {
     fs.mkdirSync(patchDir, { recursive: true });
     const filePath = join(patchDir, 'temp.patch');
     fs.writeFileSync(filePath, data);
-    const streamPatches = await Parser.parsePatchFileStream({ filePath });
+    const streamPatches = await Parser.parsePatchFile({ filePath, useStream: true });
     fs.unlinkSync(filePath);
     expect(streamPatches).toEqual(patches);
   });


### PR DESCRIPTION
## Summary
- consolidate patch parsing into single `parsePatchFile` that supports file path or data and optional streaming with size detection
- centralize comment filtering in a shared line processor
- update patch runner and tests to use the unified API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cf005d7d88325ab923eefd66bace4