### PR TITLE
feat(commands): support command cwd and timeout

### DIFF
--- a/source/lib/commands/command.ts
+++ b/source/lib/commands/command.ts
@@ -34,10 +34,10 @@ export namespace Command {
      * @returns Command output
      * @since 0.0.1
      */
-    export async function runCommand({ command, parameters, shell = false, timeout, maxBuffer }:
-        { command: string, parameters: string[], shell?: boolean, timeout?: number, maxBuffer?: number }): Promise<CommandResult> {
+    export async function runCommand({ command, parameters, shell = false, timeout, maxBuffer, cwd }:
+        { command: string, parameters: string[], shell?: boolean, timeout?: number, maxBuffer?: number, cwd?: string }): Promise<CommandResult> {
         try {
-            const result = await runCommandPromise({ command, parameters, shell, timeout, maxBuffer });
+            const result = await runCommandPromise({ command, parameters, shell, timeout, maxBuffer, cwd });
             return result;
         } catch (error) {
             if (error instanceof CommandError) {
@@ -70,11 +70,11 @@ export namespace Command {
      * @returns Command output 
      * @since 0.0.1
      */
-    export async function runCommandPromise({ command, parameters, shell = false, timeout, maxBuffer }:
-        { command: string, parameters: string[], shell?: boolean, timeout?: number, maxBuffer?: number }): Promise<CommandResult> {
+    export async function runCommandPromise({ command, parameters, shell = false, timeout, maxBuffer, cwd }:
+        { command: string, parameters: string[], shell?: boolean, timeout?: number, maxBuffer?: number, cwd?: string }): Promise<CommandResult> {
 
         return new Promise(function (resolve, reject) {
-            const childProcess: ChildProcessWithoutNullStreams = spawn(command, parameters, { shell });
+            const childProcess: ChildProcessWithoutNullStreams = spawn(command, parameters, { shell, cwd });
             const limit = maxBuffer ?? 1024 * 1024; // default 1MB per stream
             let timedOut = false;
             let timer: NodeJS.Timeout | undefined;

--- a/source/lib/commands/commands.ts
+++ b/source/lib/commands/commands.ts
@@ -111,7 +111,13 @@ export namespace Commands {
             if (command.enabled === true) {
                 logInfo(`Running general command ${command.name}: ${command.command}`);
                 const DEFAULT_TIMEOUT = 60_000; // 60 seconds
-                const { stdout, stderr, exitCode } = await runCommand({ command: command.command, parameters: [], timeout: DEFAULT_TIMEOUT });
+                const timeout = command.timeout ?? DEFAULT_TIMEOUT;
+                const { stdout, stderr, exitCode } = await runCommand({
+                    command: command.command,
+                    parameters: [],
+                    timeout,
+                    cwd: command.cwd
+                });
                 if (stdout)
                     logInfo(stdout);
                 if (stderr)

--- a/source/lib/configuration/configuration.schema.ts
+++ b/source/lib/configuration/configuration.schema.ts
@@ -119,7 +119,9 @@ export const configurationSchema = {
                         properties: {
                             name: { type: 'string' },
                             command: { type: 'string' },
-                            enabled: { type: 'boolean' }
+                            enabled: { type: 'boolean' },
+                            timeout: { type: 'number' },
+                            cwd: { type: 'string' }
                         },
                         required: ['name', 'command', 'enabled'],
                         additionalProperties: true

--- a/source/lib/configuration/configuration.types.ts
+++ b/source/lib/configuration/configuration.types.ts
@@ -80,7 +80,9 @@ export type ConfigurationObject = {
             {
                 name: string,
                 command: string,
-                enabled: boolean
+                enabled: boolean,
+                timeout?: number,
+                cwd?: string
             }
         ] | []
     },

--- a/test/command.test.js
+++ b/test/command.test.js
@@ -38,3 +38,15 @@ describe('Command.runCommandPromise timeout handling', () => {
     ).rejects.toMatchObject({ name: 'CommandError' });
   });
 });
+
+describe('Command.runCommandPromise cwd handling', () => {
+  test('runs command in specified cwd', async () => {
+    const Command = (await import('../source/lib/commands/command.js')).default;
+    const result = await Command.runCommandPromise({
+      command: 'node',
+      parameters: ['-e', "console.log(process.cwd())"],
+      cwd: '/'
+    });
+    expect(result.stdout).toBe('/\n');
+  });
+});

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -54,7 +54,7 @@ describe('Commands.runCommandsGeneral', () => {
       { name: 'test', command: 'echo hi', enabled: true }
     ];
     await Commands.runCommandsGeneral({ configuration: config });
-    expect(Command.default.runCommand).toHaveBeenCalledWith({ command: 'echo hi', parameters: [], timeout: 60000 });
+    expect(Command.default.runCommand).toHaveBeenCalledWith({ command: 'echo hi', parameters: [], timeout: 60000, cwd: undefined });
   });
 
   test('skips disabled general commands', async () => {
@@ -64,5 +64,14 @@ describe('Commands.runCommandsGeneral', () => {
     ];
     await Commands.runCommandsGeneral({ configuration: config });
     expect(Command.default.runCommand).not.toHaveBeenCalled();
+  });
+
+  test('respects timeout and cwd when provided', async () => {
+    const config = ConfigurationDefaults.getDefaultConfigurationObject();
+    config.commands.general = [
+      { name: 'test', command: 'echo hi', enabled: true, timeout: 500, cwd: '/tmp' }
+    ];
+    await Commands.runCommandsGeneral({ configuration: config });
+    expect(Command.default.runCommand).toHaveBeenCalledWith({ command: 'echo hi', parameters: [], timeout: 500, cwd: '/tmp' });
   });
 });


### PR DESCRIPTION
## Summary
- allow configuration of optional `timeout` and `cwd` for general commands
- execute general commands with custom working directory and timeout
- test command cwd and timeout handling

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689ceff7d120832581538bd2fcd09224