### PR TITLE
Run filedrops in parallel

### DIFF
--- a/test/build.test.js
+++ b/test/build.test.js
@@ -143,7 +143,7 @@ describe('Predist.predistPackage', () => {
 });
 
 describe('Packaging.runPackings', () => {
-  test('runs packing and encryption in order', async () => {
+  test('runs packing and encryption for enabled filedrops', async () => {
     const config = ConfigurationDefaults.getDefaultConfigurationObject();
     config.filedrops = [
       { name: 'a', fileDropName: 'out1', packedFileName: 'p1', fileNamePath: 'f1', decryptKey: 'k1', enabled: true },
@@ -151,22 +151,12 @@ describe('Packaging.runPackings', () => {
     ];
     await Packaging.runPackings({ configuration: config });
 
-    const order = [
-      File.default.readBinaryFile.mock.invocationCallOrder[0],
-      Packer.default.packFile.mock.invocationCallOrder[0],
-      Crypt.default.encryptFile.mock.invocationCallOrder[0],
-      File.default.writeBinaryFile.mock.invocationCallOrder[0],
-      File.default.readBinaryFile.mock.invocationCallOrder[1],
-      Packer.default.packFile.mock.invocationCallOrder[1],
-      Crypt.default.encryptFile.mock.invocationCallOrder[1],
-      File.default.writeBinaryFile.mock.invocationCallOrder[1]
-    ];
-    expect(order).toEqual(order.slice().sort((a,b)=>a-b));
-
-    expect(File.default.readBinaryFile).toHaveBeenNthCalledWith(1, { filePath: join(Constants.PATCHES_BASEUNPACKEDPATH, 'p1') });
-    expect(Packer.default.packFile).toHaveBeenNthCalledWith(1, { buffer: expect.any(Buffer), password: 'k1' });
-    expect(Crypt.default.encryptFile).toHaveBeenNthCalledWith(1, { buffer: expect.any(Buffer), key: 'k1' });
-    expect(File.default.writeBinaryFile).toHaveBeenNthCalledWith(1, { filePath: join(Constants.PATCHES_BASEPATH, 'out1'), buffer: expect.any(Buffer) });
+    expect(File.default.readBinaryFile).toHaveBeenCalledWith({ filePath: join(Constants.PATCHES_BASEUNPACKEDPATH, 'p1') });
+    expect(File.default.readBinaryFile).toHaveBeenCalledWith({ filePath: join(Constants.PATCHES_BASEUNPACKEDPATH, 'p2') });
+    expect(Packer.default.packFile).toHaveBeenCalledTimes(2);
+    expect(Crypt.default.encryptFile).toHaveBeenCalledTimes(2);
+    expect(File.default.writeBinaryFile).toHaveBeenCalledWith({ filePath: join(Constants.PATCHES_BASEPATH, 'out1'), buffer: expect.any(Buffer) });
+    expect(File.default.writeBinaryFile).toHaveBeenCalledWith({ filePath: join(Constants.PATCHES_BASEPATH, 'out2'), buffer: expect.any(Buffer) });
   });
 
   test('disabled filedrops are skipped', async () => {

--- a/test/packaging.parallel.test.js
+++ b/test/packaging.parallel.test.js
@@ -1,0 +1,61 @@
+import { jest } from '@jest/globals';
+import { ConfigurationDefaults } from '../source/lib/configuration/configuration.defaults.ts';
+
+const readResolvers = [];
+
+jest.unstable_mockModule('../source/lib/auxiliary/file.js', () => ({
+  default: {
+    readBinaryFile: jest.fn(() => new Promise(resolve => readResolvers.push(resolve))),
+    writeBinaryFile: jest.fn(async () => {})
+  }
+}));
+
+jest.unstable_mockModule('../source/lib/filedrops/packer.js', () => ({
+  default: { packFile: jest.fn(async ({ buffer }) => buffer) }
+}));
+
+jest.unstable_mockModule('../source/lib/filedrops/crypt.js', () => ({
+  default: { encryptFile: jest.fn(async ({ buffer }) => buffer) }
+}));
+
+let Packaging;
+let File;
+let Packer;
+let Crypt;
+
+beforeAll(async () => {
+  Packaging = (await import('../source/lib/build/packaging.ts')).Packaging;
+  File = await import('../source/lib/auxiliary/file.js');
+  Packer = await import('../source/lib/filedrops/packer.js');
+  Crypt = await import('../source/lib/filedrops/crypt.js');
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  readResolvers.length = 0;
+});
+
+describe('Packaging.runPackings parallel execution', () => {
+  test('processes filedrops concurrently', async () => {
+    const config = ConfigurationDefaults.getDefaultConfigurationObject();
+    config.filedrops = [
+      { name: 'a', fileDropName: 'out1', packedFileName: 'p1', fileNamePath: 'f1', decryptKey: 'k1', enabled: true },
+      { name: 'b', fileDropName: 'out2', packedFileName: 'p2', fileNamePath: 'f2', decryptKey: 'k2', enabled: true }
+    ];
+
+    const promise = Packaging.runPackings({ configuration: config });
+
+    expect(File.default.readBinaryFile).toHaveBeenCalledTimes(2);
+    expect(Packer.default.packFile).not.toHaveBeenCalled();
+    expect(Crypt.default.encryptFile).not.toHaveBeenCalled();
+    expect(File.default.writeBinaryFile).not.toHaveBeenCalled();
+
+    readResolvers.forEach(resolve => resolve(Buffer.from('data')));
+    await promise;
+
+    expect(Packer.default.packFile).toHaveBeenCalledTimes(2);
+    expect(Crypt.default.encryptFile).toHaveBeenCalledTimes(2);
+    expect(File.default.writeBinaryFile).toHaveBeenCalledTimes(2);
+  });
+});
+


### PR DESCRIPTION
## Summary
- Process enabled filedrops concurrently using `Promise.all` with per-task error logging
- Add parallel execution test for packing
- Adjust existing packaging tests for new concurrent behavior

## Testing
- `npm test >/tmp/unit.log 2>&1 && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_689ceffbb18083258595b840df6a4c1f