### PR TITLE
Add ISO timestamp to logger output

### DIFF
--- a/source/lib/auxiliary/logger.ts
+++ b/source/lib/auxiliary/logger.ts
@@ -38,12 +38,12 @@ function shouldLog(level: LogLevel): boolean {
 
 let writeQueue: Promise<void> = Promise.resolve();
 
-function writeToFile(message: string): void {
+function writeToFile(line: string): void {
     if (!config.filePath) return;
     const file = resolve(config.filePath);
     writeQueue = writeQueue.then(async () => {
         try {
-            await fs.appendFile(file, message + '\n');
+            await fs.appendFile(file, line + '\n');
         } catch {
             // ignore file write errors
         }
@@ -52,7 +52,7 @@ function writeToFile(message: string): void {
 
 function logMessage(level: LogLevel, message: string, color: (text: string) => string): void {
     if (!shouldLog(level)) return;
-    const line = config.timestamps ? `${new Date().toISOString()} ${message}` : message;
+    const line = `${new Date().toISOString()} ${message}`;
     log({ message: line, color });
     writeToFile(line);
 }

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -21,7 +21,7 @@ describe('Logger file output', () => {
     expect(fs.existsSync(file)).toBe(false);
     await delay(20);
     const content = await fs.promises.readFile(file, 'utf8');
-    expect(content.trim()).toBe('hello file');
+    expect(content.trim()).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z hello file$/);
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
@@ -37,7 +37,7 @@ describe('Logger file output', () => {
     Logger.logError('boom');
     await delay(20);
     const content = await fs.promises.readFile(file, 'utf8');
-    expect(content.trim()).toBe('boom');
+    expect(content.trim()).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z boom$/);
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
@@ -51,16 +51,16 @@ describe('Logger file output', () => {
     Logger.logInfo('invalid level');
     await delay(20);
     const content = await fs.promises.readFile(file, 'utf8');
-    expect(content.trim()).toBe('invalid level');
+    expect(content.trim()).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z invalid level$/);
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
-  test('prepends timestamps when enabled', async () => {
+  test('prepends timestamps', async () => {
     jest.resetModules();
     const { Logger } = await import('../source/lib/auxiliary/logger.ts');
     const dir = fs.mkdtempSync(join(os.tmpdir(), 'logger-'));
     const file = join(dir, 'out.log');
-    Logger.setConfig({ level: 'info', filePath: file, timestamps: true });
+    Logger.setConfig({ level: 'info', filePath: file });
     Logger.logInfo('timed');
     await delay(20);
     const content = await fs.promises.readFile(file, 'utf8');


### PR DESCRIPTION
## Summary
- always prefix log messages with an ISO 8601 timestamp
- persist timestamped lines when writing to files
- update logger tests to match timestamped output

## Testing
- `npm test test/logger.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689cf2a2f1508325b36e92e22641e126