### PR TITLE
Add typed composite function names

### DIFF
--- a/source/lib/composites.ts
+++ b/source/lib/composites.ts
@@ -35,6 +35,8 @@ const {
     CONFIG_FILEPATH
 } = Constants;
 
+import type { CompositeName } from './composites.types.js';
+
 export namespace Patcher {
     /**
      * Autonomously run the patcher based on config file
@@ -118,7 +120,7 @@ export namespace Patcher {
      * @since 0.0.1
      */
     export async function runFunction({ configuration, functionName }:
-        { configuration: ConfigurationObject, functionName: string }): Promise<void> {
+        { configuration: ConfigurationObject, functionName: CompositeName }): Promise<void> {
         try {
             switch (functionName) {
                 case COMP_COMMANDS:

--- a/source/lib/composites.types.ts
+++ b/source/lib/composites.types.ts
@@ -1,0 +1,5 @@
+/**
+ * Names of composite functions in the patcher
+ */
+export type CompositeName = 'commands' | 'filedrops' | 'patches';
+

--- a/source/lib/configuration/configuration.types.ts
+++ b/source/lib/configuration/configuration.types.ts
@@ -1,3 +1,5 @@
+import type { CompositeName } from '../composites.types.js';
+
 /**
  * Configuration object type, configuration read from `config.json` file
  */
@@ -7,7 +9,7 @@ export type ConfigurationObject = {
             exitOnNonAdmin: boolean,
             debug: boolean,
             logging: boolean,
-            runningOrder: string[] | [],
+            runningOrder: CompositeName[] | [],
             commandsOrder: string[] | [],
             onlyPackingMode: boolean,
             /** Interval for emitting progress messages during patching */

--- a/source/lib/configuration/constants.ts
+++ b/source/lib/configuration/constants.ts
@@ -6,6 +6,8 @@ import {
     CryptBufferSubsets
 } from '../filedrops/crypt.types.js';
 
+import type { CompositeName } from '../composites.types.js';
+
 const { floor, random } = Math;
 
 namespace Constants {
@@ -66,9 +68,9 @@ namespace Constants {
     export const CONFIG_ENCODING: BufferEncoding = `utf-8`;
 
     // COMPOSITES
-    export const COMP_COMMANDS: string = `commands`;
-    export const COMP_FILEDROPS: string = `filedrops`;
-    export const COMP_PATCHES: string = `patches`;
+    export const COMP_COMMANDS: CompositeName = `commands`;
+    export const COMP_FILEDROPS: CompositeName = `filedrops`;
+    export const COMP_PATCHES: CompositeName = `patches`;
 
     // COMMANDS
     export const COMM_TASKS: string = `tasks`;


### PR DESCRIPTION
## Summary
- define `CompositeName` union for patcher function names
- use `CompositeName` in `runFunction` and related configuration

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cf29f70848325bc13cd7d5836b758