### PR TITLE
Validate merged configuration and rethrow parsing errors

### DIFF
--- a/source/lib/configuration/configuration.ts
+++ b/source/lib/configuration/configuration.ts
@@ -127,13 +127,13 @@ export namespace Configuration {
             else
                 logSuccess(`Configuration file read successfully`);
             const configObject: unknown = JSON.parse(fileData);
-            validateConfiguration(configObject);
             const defaultConfig: ConfigurationObject = getDefaultConfigurationObject();
             const mergedConfig = mergeWithDefaults<ConfigurationObject>(defaultConfig, configObject as DeepPartial<ConfigurationObject>);
+            validateConfiguration(mergedConfig);
             return mergedConfig;
         } catch (error: any) {
             logError(`An error has occurred: ${error}`);
-            if (error instanceof Error && error.name === 'ValidationError')
+            if (error instanceof SyntaxError || (error instanceof Error && error.name === 'ValidationError'))
                 throw error;
             const emptyConfig: ConfigurationObject = getDefaultConfigurationObject();
             return emptyConfig;

--- a/test/configuration.test.js
+++ b/test/configuration.test.js
@@ -36,6 +36,14 @@ describe('Configuration.readConfigurationFile', () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  test('validation after merge rejects invalid values', async () => {
+    const invalid = { options: { general: { debug: 'false' } } };
+    const defaults = ConfigurationDefaults.getDefaultConfigurationObject();
+    const { Configuration } = await import('../source/lib/configuration/configuration.ts');
+    const merged = Configuration.mergeWithDefaults(defaults, invalid);
+    expect(() => Configuration.validateConfiguration(merged)).toThrow('Configuration validation failed');
+  });
+
   test('merges configuration with defaults for missing keys', async () => {
     const dir = fs.mkdtempSync(join(os.tmpdir(), 'cfg-'));
     const filePath = join(dir, 'config.json');
@@ -144,10 +152,10 @@ describe('Configuration.readConfigurationFile', () => {
     const { Configuration } = await import('../source/lib/configuration/configuration.ts');
     await Configuration.readConfigurationFile({ filePath });
 
-    expect(logFn).toHaveBeenCalledWith({
-      message: 'Configuration file read successfully',
+    expect(logFn).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringContaining('Configuration file read successfully'),
       color: expect.any(Function)
-    });
+    }));
     fs.rmSync(dir, { recursive: true, force: true });
   });
 

--- a/test/uac.test.js
+++ b/test/uac.test.js
@@ -17,20 +17,20 @@ describe('Uac.isAdmin', () => {
     const res = await Uac.isAdmin();
     expect(res).toBe(true);
     expect(checkFn).toHaveBeenCalled();
-    expect(logFn).toHaveBeenCalledWith({
-      message: 'Is current user admin: true',
+    expect(logFn).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringContaining('Is current user admin: true'),
       color: expect.any(Function)
-    });
+    }));
   });
 
   test('returns false and logs', async () => {
     const { Uac, logFn } = await loadUac(false);
     const res = await Uac.isAdmin();
     expect(res).toBe(false);
-    expect(logFn).toHaveBeenCalledWith({
-      message: 'Is current user admin: false',
+    expect(logFn).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringContaining('Is current user admin: false'),
       color: expect.any(Function)
-    });
+    }));
   });
 });
 
@@ -45,10 +45,10 @@ describe('Uac.adminCheck', () => {
     const { Uac } = await import('../source/lib/auxiliary/uac.ts');
     await Uac.adminCheck();
     expect(exitSpy).toHaveBeenCalledWith(1);
-    expect(logFn).toHaveBeenCalledWith({
-      message: "Exiting because user doesn't have administrator privileges",
+    expect(logFn).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringContaining("Exiting because user doesn't have administrator privileges"),
       color: expect.any(Function)
-    });
+    }));
     exitSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- Validate configuration after merging with defaults
- Rethrow JSON parse and validation errors instead of returning defaults
- Add test ensuring merged invalid configs fail validation
- Relax log message assertions to handle timestamped output

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a25be243048325ba46c5b10ef328c3