### PR TITLE
Handle patcher errors in executable

### DIFF
--- a/source/standalone/executable.ts
+++ b/source/standalone/executable.ts
@@ -21,4 +21,9 @@ const argv = yargs(hideBin(process.argv))
   .parseSync();
 
 /** Just run the patcher */
-runPatcher({ configFilePath: argv.config as string | undefined });
+try {
+  await runPatcher({ configFilePath: argv.config as string | undefined });
+} catch (error) {
+  console.error(error);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary
- ensure standalone executable exits with non-zero status when runPatcher fails

## Testing
- `npm test` *(fails: test/uac.test.js, test/configuration.test.js)*
- `node dist/standalone/executable.js --help`


------
https://chatgpt.com/codex/tasks/task_e_68a25bd21c948325a24f029e85568d5a