### PR TITLE
Improve log error messages

### DIFF
--- a/source/lib/configuration/configuration.ts
+++ b/source/lib/configuration/configuration.ts
@@ -131,8 +131,9 @@ export namespace Configuration {
             const mergedConfig = mergeWithDefaults<ConfigurationObject>(defaultConfig, configObject as DeepPartial<ConfigurationObject>);
             validateConfiguration(mergedConfig);
             return mergedConfig;
-        } catch (error: any) {
-            logError(`An error has occurred: ${error}`);
+        } catch (error: unknown) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            logError(`An error has occurred: ${errorMessage}`);
             if (error instanceof SyntaxError || (error instanceof Error && error.name === 'ValidationError'))
                 throw error;
             const emptyConfig: ConfigurationObject = getDefaultConfigurationObject();


### PR DESCRIPTION
## Summary
- Refine configuration file error logging to capture Error messages or string fallback

## Testing
- `npm test` *(fails: Parser.parsePatchFile streaming memory usage > expect(streamUsage).toBeLessThan(nonStreamUsage))*

------
https://chatgpt.com/codex/tasks/task_e_68a2f4e8af9483259175434405ddeb7b