### PR TITLE
Simplify getSlicedData byte handling

### DIFF
--- a/source/lib/filedrops/crypt.ts
+++ b/source/lib/filedrops/crypt.ts
@@ -221,10 +221,10 @@ export namespace Encryption {
      * @returns Buffer containing the sliced data
      * @since 0.0.1
      */
-    function getSlicedData({ data, subsetOptions }:
+    export function getSlicedData({ data, subsetOptions }:
         { data: Buffer, subsetOptions: SubsetOptionsObject }): Buffer {
         const { offset, bytes } = subsetOptions;
-        const sanitizedBytes: number = parseInt(bytes ? bytes.toString() : data.byteLength.toString());
+        const sanitizedBytes: number = bytes ?? data.byteLength;
         const limit: number = Math.min(offset + sanitizedBytes, data.length);
         logInfo(`reading offset at ${offset}, ${limit} bytes`);
         if (offset >= data.length)

--- a/test/crypt.test.js
+++ b/test/crypt.test.js
@@ -49,3 +49,23 @@ describe('Encryption.encryptFile and decryptFile', () => {
     expect(File.default.readBinaryFile).toHaveBeenCalledWith({ filePath: 'b.bin' });
   });
 });
+
+describe('getSlicedData', () => {
+  test('slices with explicit bytes', () => {
+    const buffer = Buffer.from('hello world');
+    const result = Crypt.getSlicedData({
+      data: buffer,
+      subsetOptions: { offset: 0, bytes: 5 }
+    });
+    expect(result.toString()).toBe('hello');
+  });
+
+  test('slices to end when bytes omitted', () => {
+    const buffer = Buffer.from('hello world');
+    const result = Crypt.getSlicedData({
+      data: buffer,
+      subsetOptions: { offset: 6 }
+    });
+    expect(result.toString()).toBe('world');
+  });
+});


### PR DESCRIPTION
## Summary
- use nullish coalescing to select byte count in `getSlicedData`
- test slicing with and without explicit byte length

## Testing
- `npm test -- test/crypt.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a36ebb7e5483259a71aae290a028c2