### PR TITLE
feat(parser): throw on parse failure

### DIFF
--- a/source/lib/patches/parser.ts
+++ b/source/lib/patches/parser.ts
@@ -80,7 +80,9 @@ export namespace Parser {
             return patches;
         } catch (error: any) {
             logError(`An error has occurred: ${error}`);
-            return [];
+            if (error instanceof PatchParseError)
+                throw error;
+            throw new PatchParseError(error?.message ?? String(error));
         }
     }
 
@@ -112,8 +114,9 @@ export namespace Parser {
             return patches;
         } catch (error: any) {
             logError(`An error has occurred: ${error}`);
-            const emptyPatchArray: PatchArray = [];
-            return emptyPatchArray;
+            if (error instanceof PatchParseError)
+                throw error;
+            throw new PatchParseError(error?.message ?? String(error));
         }
     }
 

--- a/source/lib/patches/patches.ts
+++ b/source/lib/patches/patches.ts
@@ -79,7 +79,13 @@ export namespace Patches {
 
             await prepatchChecksAndRoutines({ patchOptions, patch });
             const patchFilePath: string = join(PATCHES_BASEPATH, patch.patchFilename);
-            const patchData: PatchArray = await parsePatchFile({ filePath: patchFilePath, useStream: patchOptions.streamingParser });
+            let patchData: PatchArray;
+            try {
+                patchData = await parsePatchFile({ filePath: patchFilePath, useStream: patchOptions.streamingParser });
+            } catch (error) {
+                logError(`Failed to parse patch file ${patchFilePath}: ${error}`);
+                throw error;
+            }
             const filePath: string = resolveEnvPath({ path: patch.fileNamePath });
 
             const fileSize: number = await getFileSizeUsingPath({ filePath });

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -1,4 +1,5 @@
 import { Parser, ParserWrappers } from '../source/lib/patches/parser.ts';
+import { PatchParseError } from '../source/lib/errors/index.ts';
 import fs from 'fs';
 import { join } from 'path';
 
@@ -74,10 +75,9 @@ describe('Parser.parsePatchFile', () => {
     ]);
   });
 
-  test('returns empty array for unsupported patch size', async () => {
+  test('throws for unsupported patch size', async () => {
     const data = '00000000: 000 01';
-    const patches = await Parser.parsePatchFile({ fileData: data });
-    expect(patches).toEqual([]);
+    await expect(Parser.parsePatchFile({ fileData: data })).rejects.toThrow(PatchParseError);
   });
 
   test('parses comments and empty lines identically to streaming parser', async () => {


### PR DESCRIPTION
## Summary
- throw `PatchParseError` instead of returning empty array when parsing fails
- propagate parser errors to patch runner
- expect parse errors in tests

## Testing
- `npm test test/parser.test.js test/parser.stream.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a3b63824f883259d941ee0a940cae6