### PR TITLE
feat: merge arrays element-wise in configuration merging

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -259,9 +259,8 @@ Patcherjs functions with a configuration json file using the following structure
 
 ```
 When a configuration file is loaded its values are merged with the defaults.
-Arrays in the provided file replace their default counterparts unless a custom
-merge strategy is specified when calling
-`Configuration.mergeWithDefaults`.
+Arrays in the provided file are merged element-wise with their default
+counterparts so missing fields inherit default values.
 Enabling `verifyPatch` causes the patcher to read back each patched region to confirm it was written correctly. This extra disk read can slow patching on large files or when many patches are applied. See [`source/lib/patches/buffer.ts`](./source/lib/patches/buffer.ts) for implementation details.
 
 ## On .patch files

--- a/source/lib/configuration/configuration.ts
+++ b/source/lib/configuration/configuration.ts
@@ -54,9 +54,8 @@ export namespace Configuration {
     /**
      * Deeply merges the provided configuration object with the defaults.
      *
-     * Arrays are replaced by the provided array unless a custom merge strategy
-     * is supplied via the `options.arrayMerge` callback. The callback receives
-     * the default and provided arrays and must return the merged array.
+     * Arrays are merged element-wise so that each provided item merges with its
+     * default counterpart.
      *
      * @param defaultObj Default configuration object
      * @param providedObj Optional partial configuration
@@ -65,13 +64,14 @@ export namespace Configuration {
     export function mergeWithDefaults<T>(defaultObj: T, providedObj?: DeepPartial<T>, options: MergeOptions = {}): T {
         if (Array.isArray(defaultObj) || Array.isArray(providedObj)) {
             type Element = T extends Array<infer U> ? U : never;
-            const defaultArray = Array.isArray(defaultObj) ? defaultObj as unknown[] : [];
-            const providedArray = Array.isArray(providedObj) ? providedObj as unknown[] : undefined;
-            const mergedArray = options.arrayMerge
-                ? options.arrayMerge(defaultArray, providedArray ?? [])
-                : (providedArray ?? defaultArray);
-            return (mergedArray as unknown[]).map(item =>
-                mergeWithDefaults<Element>(item as Element, undefined, options)
+            const defaultArray = Array.isArray(defaultObj) ? (defaultObj as unknown[]) : [];
+            const providedArray = Array.isArray(providedObj) ? (providedObj as unknown[]) : undefined;
+            return defaultArray.map((item, i) =>
+                mergeWithDefaults<Element>(
+                    item as Element,
+                    providedArray?.[i] as DeepPartial<Element>,
+                    options
+                )
             ) as unknown as T;
         }
 

--- a/test/configuration.test.js
+++ b/test/configuration.test.js
@@ -88,29 +88,20 @@ describe('Configuration.readConfigurationFile', () => {
     expect(defaultObj.options.general.obj).toEqual({ a: 1 });
   });
 
-  test('replaces arrays of objects by default', async () => {
+  test('merges arrays of objects by index', async () => {
     const defaults = { patches: [{ name: 'a', enabled: true }] };
-    const provided = { patches: [{ name: 'b', enabled: false }] };
+    const provided = { patches: [{ name: 'b' }] };
     const { Configuration } = await import('../source/lib/configuration/configuration.ts');
     const result = Configuration.mergeWithDefaults(defaults, provided);
-    expect(result).toEqual({ patches: [{ name: 'b', enabled: false }] });
+    expect(result).toEqual({ patches: [{ name: 'b', enabled: true }] });
   });
 
-  test('replaces primitive arrays', async () => {
+  test('merges primitive arrays by index', async () => {
     const defaults = { nums: [1, 2] };
     const provided = { nums: [3] };
     const { Configuration } = await import('../source/lib/configuration/configuration.ts');
     const result = Configuration.mergeWithDefaults(defaults, provided);
-    expect(result.nums).toEqual([3]);
-  });
-
-  test('uses custom array merge strategy when provided', async () => {
-    const defaults = { nums: [1, 2] };
-    const provided = { nums: [3] };
-    const { Configuration } = await import('../source/lib/configuration/configuration.ts');
-    const merge = (defArr, provArr) => defArr.concat(provArr);
-    const result = Configuration.mergeWithDefaults(defaults, provided, { arrayMerge: merge });
-    expect(result.nums).toEqual([1, 2, 3]);
+    expect(result.nums).toEqual([3, 2]);
   });
 
   test('merges nested structures', async () => {


### PR DESCRIPTION
## Summary
- merge arrays in configuration using index-wise defaults so missing fields inherit defaults
- update configuration tests for new array merge behavior
- document element-wise array merging in README

## Testing
- `npm test` *(fails: Parser.parsePatchFile streaming memory usage – exceeded timeout)*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a46ac014e483258fdc03e0a737ec5d