### PR TITLE
refactor: improve command type error logging

### DIFF
--- a/source/lib/commands/commands.ts
+++ b/source/lib/commands/commands.ts
@@ -81,7 +81,8 @@ export namespace Commands {
                 throw new Error(`Unknown command type: ${functionName}`);
             await fn({ configuration });
         } catch (error) {
-            logError(`Failed to process command type ${error}`);
+            const msg = error instanceof Error ? error.message : String(error);
+            logError(`Failed to process command type ${msg}`);
         }
     }
 


### PR DESCRIPTION
## Summary
- refine command type error handling to log clean error messages

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a4a0c063508325a5e7470e4c3636eb