### PR TITLE
fix: avoid append in writeBinaryFile

### DIFF
--- a/source/lib/auxiliary/file.ts
+++ b/source/lib/auxiliary/file.ts
@@ -130,8 +130,8 @@ export namespace File {
         let fileHandle: fs.FileHandle | undefined;
         try {
             const fileExists: boolean = await isFileReadable({ filePath });
-            const flags: string = fileExists ? 'r+' : 'a';
-            logInfo(`Opening file path, ${filePath}, in ${fileExists ? 'read/write' : 'append'} mode`);
+            const flags: string = fileExists ? 'r+' : 'w';
+            logInfo(`Opening file path, ${filePath}, in ${fileExists ? 'read/write' : 'write'} mode`);
             fileHandle = await fs.open(filePath, flags);
             if (fileExists) {
                 const originalSize: number = await getFileSize({ fileHandle });

--- a/test/file.util.test.js
+++ b/test/file.util.test.js
@@ -32,6 +32,18 @@ describe('File utilities', () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  test('writeBinaryFile overwrites existing files', async () => {
+    const dir = fs.mkdtempSync(join(os.tmpdir(), 'fileutil-'));
+    const p = join(dir, 'out.bin');
+    const buf1 = Buffer.from([1, 2, 3, 4]);
+    const buf2 = Buffer.from([5, 6]);
+    await File.writeBinaryFile({ filePath: p, buffer: buf1 });
+    await File.writeBinaryFile({ filePath: p, buffer: buf2 });
+    const data = fs.readFileSync(p);
+    expect(data.equals(buf2)).toBe(true);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   test('writeBinaryFile returns 0 on failure', async () => {
     const bytes = await File.writeBinaryFile({ filePath: '/no/path/out.bin', buffer: Buffer.from([1]) });
     expect(bytes).toBe(0);


### PR DESCRIPTION
## Summary
- open new binary files in write mode to avoid unintended appends
- add test ensuring writeBinaryFile overwrites existing files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4c3ed62c483259eb367d46f557f81