### PR TITLE
feat(logger): make timestamps optional

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -99,6 +99,10 @@ Run the Jest suite with the provided npm script. It builds the TypeScript source
 npm test
 ```
 
+#### Logger configuration
+
+The logger can prefix each message with an ISO timestamp. Enable timestamps by setting the environment variable `LOG_TIMESTAMPS=true` or by calling `Logger.setConfig({ timestamps: true })`. When not enabled, messages are written without a timestamp.
+
 #### Example files
 
 The project comes with an example `.patch` file and a `.dll` file to be packed, these files should be removed and you should add your own files.

--- a/source/lib/auxiliary/logger.ts
+++ b/source/lib/auxiliary/logger.ts
@@ -29,6 +29,7 @@ function getLogLevel(level?: string): LogLevel {
 let config: LoggerConfig = {
     level: getLogLevel(process.env.LOG_LEVEL),
     filePath: process.env.LOG_FILEPATH,
+    // include ISO timestamps only when explicitly enabled
     timestamps: process.env.LOG_TIMESTAMPS === 'true'
 };
 
@@ -52,7 +53,9 @@ function writeToFile(line: string): void {
 
 function logMessage(level: LogLevel, message: string, color: (text: string) => string): void {
     if (!shouldLog(level)) return;
-    const line = `${new Date().toISOString()} ${message}`;
+    const line = config.timestamps
+        ? `${new Date().toISOString()} ${message}`
+        : message;
     log({ message: line, color });
     writeToFile(line);
 }

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -16,7 +16,7 @@ describe('Logger file output', () => {
     const { Logger } = await import('../source/lib/auxiliary/logger.ts');
     const dir = fs.mkdtempSync(join(os.tmpdir(), 'logger-'));
     const file = join(dir, 'out.log');
-    Logger.setConfig({ level: 'info', filePath: file });
+    Logger.setConfig({ level: 'info', filePath: file, timestamps: true });
     Logger.logInfo('hello file');
     expect(fs.existsSync(file)).toBe(false);
     await delay(20);
@@ -30,7 +30,7 @@ describe('Logger file output', () => {
     const { Logger } = await import('../source/lib/auxiliary/logger.ts');
     const dir = fs.mkdtempSync(join(os.tmpdir(), 'logger-'));
     const file = join(dir, 'out.log');
-    Logger.setConfig({ level: 'error', filePath: file });
+    Logger.setConfig({ level: 'error', filePath: file, timestamps: true });
     Logger.logWarn('skip this');
     await delay(20);
     expect(fs.existsSync(file)).toBe(false);
@@ -47,7 +47,7 @@ describe('Logger file output', () => {
     const { Logger } = await import('../source/lib/auxiliary/logger.ts');
     const dir = fs.mkdtempSync(join(os.tmpdir(), 'logger-'));
     const file = join(dir, 'out.log');
-    Logger.setConfig({ filePath: file });
+    Logger.setConfig({ filePath: file, timestamps: true });
     Logger.logInfo('invalid level');
     await delay(20);
     const content = await fs.promises.readFile(file, 'utf8');
@@ -55,16 +55,29 @@ describe('Logger file output', () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
-  test('prepends timestamps', async () => {
+  test('prepends timestamps when enabled', async () => {
     jest.resetModules();
     const { Logger } = await import('../source/lib/auxiliary/logger.ts');
     const dir = fs.mkdtempSync(join(os.tmpdir(), 'logger-'));
     const file = join(dir, 'out.log');
-    Logger.setConfig({ level: 'info', filePath: file });
+    Logger.setConfig({ level: 'info', filePath: file, timestamps: true });
     Logger.logInfo('timed');
     await delay(20);
     const content = await fs.promises.readFile(file, 'utf8');
     expect(content.trim()).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z timed$/);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('logs raw message when timestamps disabled', async () => {
+    jest.resetModules();
+    const { Logger } = await import('../source/lib/auxiliary/logger.ts');
+    const dir = fs.mkdtempSync(join(os.tmpdir(), 'logger-'));
+    const file = join(dir, 'out.log');
+    Logger.setConfig({ level: 'info', filePath: file, timestamps: false });
+    Logger.logInfo('plain');
+    await delay(20);
+    const content = await fs.promises.readFile(file, 'utf8');
+    expect(content.trim()).toBe('plain');
     fs.rmSync(dir, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## Summary
- log timestamps only when explicitly enabled
- document how to configure logger timestamps
- test timestamp on/off behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4c3e7b93083259ad8a7c03c29c95f