### PR TITLE
Propagate file I/O errors

### DIFF
--- a/source/lib/auxiliary/file.ts
+++ b/source/lib/auxiliary/file.ts
@@ -61,7 +61,7 @@ export namespace File {
             return fileData;
         } catch (error: any) {
             logError(`An error has occurred: ${error}`);
-            return '';
+            throw error;
         } finally {
             if (fileHandle) {
                 await fileHandle.close();
@@ -103,7 +103,7 @@ export namespace File {
             return buffer;
         } catch (error: any) {
             logError(`An error has occurred: ${error}`);
-            return createBuffer({ size: 0 });
+            throw error;
         } finally {
             if (fileHandle) {
                 await fileHandle.close();
@@ -153,7 +153,7 @@ export namespace File {
             return bytesWritten;
         } catch (error: any) {
             logError(`An error has occurred: ${error}`);
-            return 0;
+            throw error;
         } finally {
             if (fileHandle) {
                 await fileHandle.close();


### PR DESCRIPTION
## Summary
- throw file reading/writing errors instead of returning default values
- adjust tests for new rejection behavior and cover unreadable/unwritable scenarios

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a613f57c1c8325862efeb3dca1c7c8