### PR TITLE
feat: continue running commands after failure

### DIFF
--- a/source/lib/commands/commands.ts
+++ b/source/lib/commands/commands.ts
@@ -105,17 +105,22 @@ export namespace Commands {
                 logInfo(`Running general command ${command.name}: ${command.command}`);
                 const DEFAULT_TIMEOUT = 60_000; // 60 seconds
                 const timeout = command.timeout ?? DEFAULT_TIMEOUT;
-                const { stdout, stderr, exitCode } = await runCommand({
-                    command: command.command,
-                    parameters: [],
-                    timeout,
-                    cwd: command.cwd
-                });
-                if (stdout)
-                    logInfo(stdout);
-                if (stderr)
-                    logError(stderr);
-                logInfo(`Command exited with code ${exitCode}`);
+                try {
+                    const { stdout, stderr, exitCode } = await runCommand({
+                        command: command.command,
+                        parameters: [],
+                        timeout,
+                        cwd: command.cwd
+                    });
+                    if (stdout)
+                        logInfo(stdout);
+                    if (stderr)
+                        logError(stderr);
+                    logInfo(`Command exited with code ${exitCode}`);
+                } catch (error) {
+                    const msg = error instanceof Error ? error.message : String(error);
+                    logError(`Failed to execute command ${command.name}: ${msg}`);
+                }
             }
     }
 }


### PR DESCRIPTION
## Summary
- keep running general commands even if one fails
- log errors when a general command throws

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6f9b8a26083259d43fdbc2379c85a