### PR TITLE
Improve patch parsing validation

### DIFF
--- a/source/lib/patches/parser.ts
+++ b/source/lib/patches/parser.ts
@@ -143,7 +143,14 @@ export namespace Parser {
             const previousNewValueDelimiter = ' ';
 
             const [offsetString, valuesString] = patchLine.split(offsetValuesDelimiter);
+            if (!offsetString || !valuesString)
+                throw new PatchParseError(`Patch at line ${index + 1} is missing offset or values`);
+
             const [previousValueString, newValueString] = valuesString.split(previousNewValueDelimiter);
+            if (!previousValueString || !newValueString)
+                throw new PatchParseError(`Patch at line ${index + 1} is missing previous or new value`);
+            if (previousValueString.length !== newValueString.length)
+                throw new PatchParseError(`Patch at line ${index + 1} previous and new values length mismatch`);
 
             const valueLength = Math.max(previousValueString.length, newValueString.length);
             const byteLength = valueLength / 2;


### PR DESCRIPTION
## Summary
- Validate presence of offset and value segments when parsing patch lines
- Ensure previous and new values exist and are of equal length

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a74863629c83259d948ab3c2555596