### PR TITLE
feat: support pattern-based patch offsets

### DIFF
--- a/docs/functions/Patches.runPatches.html
+++ b/docs/functions/Patches.runPatches.html
@@ -21,6 +21,7 @@
 <li class="tsd-signature tsd-anchor-link" id="runPatches"><span class="tsd-kind-call-signature">run<wbr/>Patches</span><span class="tsd-signature-symbol">(</span><span class="tsd-kind-parameter">__namedParameters</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type ">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span><a href="#runPatches" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24"><g stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" id="icon-anchor"><path stroke="none" d="M0 0h24v24H0z" fill="none"></path><path d="M10 14a3.5 3.5 0 0 0 5 0l4 -4a3.5 3.5 0 0 0 -5 -5l-.5 .5"></path><path d="M14 10a3.5 3.5 0 0 0 -5 0l-4 4a3.5 3.5 0 0 0 5 5l.5 -.5"></path></g></svg></a></li>
 <li class="tsd-description">
 <div class="tsd-comment tsd-typography"><p>All encompassing function that runs every patch with a configuration file</p>
+<p>Patch files may specify either a numeric offset or a space-separated byte pattern in place of the offset. When a pattern is provided the file is searched and the patch is applied at the first match.</p>
 </div>
 <div class="tsd-parameters">
 <h4 class="tsd-parameters-title">Parameters</h4>

--- a/source/lib/patches/parser.types.ts
+++ b/source/lib/patches/parser.types.ts
@@ -3,7 +3,9 @@
  */
 export type PatchObject = {
     /** Decimal offset value */
-    offset: bigint,
+    offset?: bigint,
+    /** Byte pattern to locate offset dynamically */
+    pattern?: Buffer | string | number[],
     /** Decimal current/previous value to find */
     previousValue: number | bigint,
     /** Decimal new value to previous/current value */


### PR DESCRIPTION
## Summary
- allow patch definitions to specify byte patterns instead of numeric offsets
- search for patterns in BufferUtils to resolve offsets on the fly
- document pattern syntax and test pattern-based patching

## Testing
- `npm test test/patches.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68aca8ae66448325a4ad77653e56fa0f