### PR TITLE
feat: support unix admin detection

### DIFF
--- a/source/lib/auxiliary/uac.ts
+++ b/source/lib/auxiliary/uac.ts
@@ -19,9 +19,20 @@ export namespace Uac {
      */
     export async function isAdmin(): Promise<boolean> {
         try {
-            const isAdministrator: boolean = await isElevated.check();
-            logInfo(`Is current user admin: ${isAdministrator}`);
-            return isAdministrator;
+            if (process.platform === 'win32') {
+                const isAdministrator: boolean = await isElevated.check();
+                logInfo(`Is current user admin: ${isAdministrator}`);
+                return isAdministrator;
+            }
+
+            if (typeof process.getuid === 'function') {
+                const isAdministrator: boolean = process.getuid() === 0;
+                logInfo(`Is current user admin: ${isAdministrator}`);
+                return isAdministrator;
+            }
+
+            logInfo('Is current user admin: false');
+            return false;
         } catch {
             return false;
         }

--- a/test/uac.test.js
+++ b/test/uac.test.js
@@ -1,54 +1,94 @@
 import { jest } from '@jest/globals';
 
-async function loadUac(checkValue) {
+const realPlatform = process.platform;
+const realGetuid = process.getuid;
+
+afterEach(() => {
+  Object.defineProperty(process, 'platform', { value: realPlatform });
+  if (typeof realGetuid === 'function') {
+    process.getuid = realGetuid;
+  } else {
+    delete process.getuid;
+  }
   jest.resetModules();
+});
+
+async function loadWindows(checkValue) {
+  Object.defineProperty(process, 'platform', { value: 'win32' });
+  delete process.getuid;
   const checkFn = jest.fn(() => checkValue);
   jest.unstable_mockModule('elevated', () => ({ check: checkFn }));
-  const logFn = jest.fn();
-  jest.unstable_mockModule('../source/lib/auxiliary/debug.js', () => ({ default: { log: logFn } }));
+  const logInfo = jest.fn();
+  const logError = jest.fn();
+  jest.unstable_mockModule('../source/lib/auxiliary/logger.js', () => ({ default: { logInfo, logError } }));
   const mod = await import('../source/lib/auxiliary/uac.ts');
-  const Debug = await import('../source/lib/auxiliary/debug.js');
-  return { Uac: mod.Uac, logFn: Debug.default.log, checkFn };
+  return { Uac: mod.Uac, logInfo, logError, checkFn };
 }
 
-describe('Uac.isAdmin', () => {
+async function loadUnix(uid) {
+  Object.defineProperty(process, 'platform', { value: 'linux' });
+  process.getuid = jest.fn(() => uid);
+  const checkFn = jest.fn();
+  jest.unstable_mockModule('elevated', () => ({ check: checkFn }));
+  const logInfo = jest.fn();
+  const logError = jest.fn();
+  jest.unstable_mockModule('../source/lib/auxiliary/logger.js', () => ({ default: { logInfo, logError } }));
+  const mod = await import('../source/lib/auxiliary/uac.ts');
+  return { Uac: mod.Uac, logInfo, logError, checkFn, getuid: process.getuid };
+}
+
+describe('Uac.isAdmin on Windows', () => {
   test('returns true and logs', async () => {
-    const { Uac, logFn, checkFn } = await loadUac(true);
+    const { Uac, logInfo, checkFn } = await loadWindows(true);
     const res = await Uac.isAdmin();
     expect(res).toBe(true);
     expect(checkFn).toHaveBeenCalled();
-    expect(logFn).toHaveBeenCalledWith(expect.objectContaining({
-      message: expect.stringContaining('Is current user admin: true'),
-      color: expect.any(Function)
-    }));
+    expect(logInfo).toHaveBeenCalledWith(expect.stringContaining('Is current user admin: true'));
   });
 
   test('returns false and logs', async () => {
-    const { Uac, logFn } = await loadUac(false);
+    const { Uac, logInfo, checkFn } = await loadWindows(false);
     const res = await Uac.isAdmin();
     expect(res).toBe(false);
-    expect(logFn).toHaveBeenCalledWith(expect.objectContaining({
-      message: expect.stringContaining('Is current user admin: false'),
-      color: expect.any(Function)
-    }));
+    expect(checkFn).toHaveBeenCalled();
+    expect(logInfo).toHaveBeenCalledWith(expect.stringContaining('Is current user admin: false'));
+  });
+});
+
+describe('Uac.isAdmin on Unix', () => {
+  test('returns true and logs', async () => {
+    const { Uac, logInfo, getuid, checkFn } = await loadUnix(0);
+    const res = await Uac.isAdmin();
+    expect(res).toBe(true);
+    expect(checkFn).not.toHaveBeenCalled();
+    expect(getuid).toHaveBeenCalled();
+    expect(logInfo).toHaveBeenCalledWith(expect.stringContaining('Is current user admin: true'));
+  });
+
+  test('returns false and logs', async () => {
+    const { Uac, logInfo, getuid, checkFn } = await loadUnix(1000);
+    const res = await Uac.isAdmin();
+    expect(res).toBe(false);
+    expect(checkFn).not.toHaveBeenCalled();
+    expect(getuid).toHaveBeenCalled();
+    expect(logInfo).toHaveBeenCalledWith(expect.stringContaining('Is current user admin: false'));
   });
 });
 
 describe('Uac.adminCheck', () => {
   test('exits when user is not admin', async () => {
-    jest.resetModules();
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    delete process.getuid;
     const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
     const checkFn = jest.fn(() => false);
     jest.unstable_mockModule('elevated', () => ({ check: checkFn }));
-    const logFn = jest.fn();
-    jest.unstable_mockModule('../source/lib/auxiliary/debug.js', () => ({ default: { log: logFn } }));
+    const logInfo = jest.fn();
+    const logError = jest.fn();
+    jest.unstable_mockModule('../source/lib/auxiliary/logger.js', () => ({ default: { logInfo, logError } }));
     const { Uac } = await import('../source/lib/auxiliary/uac.ts');
     await Uac.adminCheck();
     expect(exitSpy).toHaveBeenCalledWith(1);
-    expect(logFn).toHaveBeenCalledWith(expect.objectContaining({
-      message: expect.stringContaining("Exiting because user doesn't have administrator privileges"),
-      color: expect.any(Function)
-    }));
+    expect(logError).toHaveBeenCalledWith(expect.stringContaining("Exiting because user doesn't have administrator privileges"));
     exitSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- use `process.platform` to handle OS-specific admin checks
- return false for unsupported environments
- add windows and unix test coverage for UAC checks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acdcc8fa988325a569613b44498be8