### PR TITLE
Add optional SHA256 verification for filedrops

### DIFF
--- a/config.json
+++ b/config.json
@@ -88,6 +88,7 @@
       "packedFileName": "helloworld.dll",
       "fileNamePath": "${HOME}/Someapp/helloworld.dll",
       "decryptKey": "ad4bc8a11481000e4d8daf28412f867a",
+      "sha256": "",
       "enabled": true
     }
   ]

--- a/readme.md
+++ b/readme.md
@@ -256,12 +256,14 @@ Patcherjs functions with a configuration json file using the following structure
       "packedFileName": "helloworld.dll", // Original filename inside 'patch_files_unpacked' folder
       "fileNamePath": "${HOME}/Someapp/helloworld.dll", // Destination filename, using HOME for cross-platform support
       "decryptKey": "ad4bc8a11481000e4d8daf28412f867a", // Encryption/decryption password
+      "sha256": "", // Optional expected SHA256 of the final file
       "enabled": true // Set to false to skip
     }
   ]
 }
 
 ```
+Specifying `sha256` for a filedrop verifies the written file's SHA-256 hash and aborts on mismatch.
 When a configuration file is loaded its values are merged with the defaults.
 Arrays in the provided file are merged element-wise with their default
 counterparts so missing fields inherit default values.

--- a/source/lib/configuration/configuration.defaults.ts
+++ b/source/lib/configuration/configuration.defaults.ts
@@ -70,7 +70,7 @@ export namespace ConfigurationDefaults {
                 services: [],
                 general: []
             },
-            filedrops: []
+            filedrops: [] as ConfigurationObject['filedrops']
         };
 
         return defaultConfigurationObject;

--- a/source/lib/configuration/configuration.schema.ts
+++ b/source/lib/configuration/configuration.schema.ts
@@ -143,7 +143,8 @@ export const configurationSchema = {
                     packedFileName: { type: 'string' },
                     fileNamePath: { type: 'string' },
                     decryptKey: { type: 'string' },
-                    enabled: { type: 'boolean' }
+                    enabled: { type: 'boolean' },
+                    sha256: { type: 'string' }
                 },
                 required: ['name', 'fileDropName', 'packedFileName', 'fileNamePath', 'decryptKey', 'enabled'],
                 additionalProperties: true

--- a/source/lib/configuration/configuration.types.ts
+++ b/source/lib/configuration/configuration.types.ts
@@ -95,7 +95,8 @@ export type ConfigurationObject = {
             packedFileName: string,
             fileNamePath: string,
             decryptKey: string,
-            enabled: boolean
+            enabled: boolean,
+            sha256?: string
         }
     ] | []
 };

--- a/source/lib/filedrops/filedrops.ts
+++ b/source/lib/filedrops/filedrops.ts
@@ -14,6 +14,7 @@ import Logger from '../auxiliary/logger.js';
 const { logInfo, logError, logSuccess } = Logger;
 import { join, dirname } from 'path';
 import { mkdir } from 'fs/promises';
+import { createHash } from 'crypto';
 
 import { ConfigurationObject, FiledropsObject, FiledropsOptionsObject } from '../configuration/configuration.types.js';
 
@@ -73,6 +74,11 @@ export namespace Filedrops {
                 fileData = await unpackFile({ buffer: fileData, password: filedrop.decryptKey });
             const destinationPath: string = resolveEnvPath({ path: filedrop.fileNamePath });
             await writeBinaryFile({ filePath: destinationPath, buffer: fileData });
+            const writtenHash: string = createHash('sha256').update(fileData).digest('hex');
+            if (filedrop.sha256 && writtenHash !== filedrop.sha256) {
+                logError(`SHA256 mismatch for dropped file`);
+                return;
+            }
             logSuccess(`File was dropped successfully`);
         } catch (error) {
             logError(`There was an error while dropping a file: ${error}`);


### PR DESCRIPTION
## Summary
- allow filedrops to specify an optional `sha256` checksum
- validate dropped files against provided checksums
- document `sha256` usage in configuration and README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae0204a1dc83259925f2158d2b2074