### PR TITLE
feat: support yaml configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "debug": "^4.3.4",
         "elevated": "^1.1.5",
         "esbuild": "0.25.8",
+        "js-yaml": "^4.1.0",
         "node-7z": "^3.0.0",
         "supports-color": "^9.4.0",
         "tmp": "^0.2.1",
@@ -2951,7 +2952,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/async": {
@@ -5222,7 +5222,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "debug": "^4.3.4",
     "elevated": "^1.1.5",
     "esbuild": "0.25.8",
+    "js-yaml": "^4.1.0",
     "node-7z": "^3.0.0",
     "supports-color": "^9.4.0",
     "tmp": "^0.2.1",

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ Simple running example
 import { Patcher } from 'patcherjs';
 
 Patcher.runPatcher({});
-Patcher.runPatcher({ configFilePath: './my-config.json', waitForExit: false });
+Patcher.runPatcher({ configFilePath: './my-config.yaml', waitForExit: false });
 ```
 
 ### Use as standalone application or development
@@ -47,10 +47,10 @@ $ git clone https://github.com/supermarsx/patcherjs
 $ npm install
 $ npm run ts-build
 $ node dist/standalone/executable.js
-$ node dist/standalone/executable.js --config ./my-config.json
-$ node dist/standalone/executable.js -c ./my-config.json
+$ node dist/standalone/executable.js --config ./my-config.yaml
+$ node dist/standalone/executable.js -c ./my-config.yaml
 ```
-The `--config` (or `-c`) option allows you to specify a custom configuration file instead of the default `config.json`. You can also use the form `--config=<path>`.
+The `--config` (or `-c`) option allows you to specify a custom configuration file instead of the default `config.json`. Both JSON and YAML files are supported. You can also use the form `--config=<path>`.
 
 #### Running on Linux/macOS
 
@@ -58,8 +58,8 @@ Once the project adds support for these platforms the steps are the same:
 
 ```bash
 npm run ts-build
-node dist/standalone/executable.js --config ./my-config.json
-node dist/standalone/executable.js --config=./my-config.json
+node dist/standalone/executable.js --config ./my-config.yaml
+node dist/standalone/executable.js --config=./my-config.yaml
 ```
 The build pipeline will skip the signing step on non-Windows systems.
 #### npm scripts


### PR DESCRIPTION
## Summary
- allow configuration files or inline content in YAML via js-yaml
- mention YAML usage in README examples
- test YAML and JSON configs produce the same configuration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aecc8a0fb08325895c034cbf83d890