### PR TITLE
feat: stream command output with callbacks

### DIFF
--- a/source/lib/commands/commands.ts
+++ b/source/lib/commands/commands.ts
@@ -106,16 +106,14 @@ export namespace Commands {
                 const DEFAULT_TIMEOUT = 60_000; // 60 seconds
                 const timeout = command.timeout ?? DEFAULT_TIMEOUT;
                 try {
-                    const { stdout, stderr, exitCode } = await runCommand({
+                    const { exitCode } = await runCommand({
                         command: command.command,
                         parameters: [],
                         timeout,
-                        cwd: command.cwd
+                        cwd: command.cwd,
+                        onStdout: (chunk: string) => logInfo(chunk),
+                        onStderr: (chunk: string) => logError(chunk)
                     });
-                    if (stdout)
-                        logInfo(stdout);
-                    if (stderr)
-                        logError(stderr);
                     logInfo(`Command exited with code ${exitCode}`);
                 } catch (error) {
                     const msg = error instanceof Error ? error.message : String(error);

--- a/test/command.incremental.test.js
+++ b/test/command.incremental.test.js
@@ -1,0 +1,46 @@
+import { jest } from '@jest/globals';
+import { EventEmitter } from 'events';
+
+describe('Command.runCommandPromise incremental logging', () => {
+  test('forwards stdout and stderr chunks respecting maxBuffer', async () => {
+    jest.resetModules();
+    const spawnMock = jest.fn();
+    jest.unstable_mockModule('child_process', () => ({ spawn: spawnMock }));
+    const Command = (await import('../source/lib/commands/command.js')).default;
+
+    const stdoutChunks = [];
+    const stderrChunks = [];
+
+    spawnMock.mockImplementation(() => {
+      const cp = new EventEmitter();
+      const stdout = new EventEmitter();
+      const stderr = new EventEmitter();
+      // @ts-ignore
+      cp.stdout = stdout;
+      // @ts-ignore
+      cp.stderr = stderr;
+      // @ts-ignore
+      cp.kill = jest.fn();
+      process.nextTick(() => {
+        stdout.emit('data', Buffer.from('123'));
+        stdout.emit('data', Buffer.from('456'));
+        stdout.emit('data', Buffer.from('789'));
+        stderr.emit('data', Buffer.from('err'));
+        cp.emit('close', 0);
+      });
+      return cp;
+    });
+
+    const result = await Command.runCommandPromise({
+      command: 'fake',
+      parameters: [],
+      maxBuffer: 5,
+      onStdout: (chunk) => stdoutChunks.push(chunk),
+      onStderr: (chunk) => stderrChunks.push(chunk)
+    });
+
+    expect(stdoutChunks).toEqual(['123', '45']);
+    expect(stderrChunks).toEqual(['err']);
+    expect(result).toEqual({ stdout: '12345', stderr: 'err', exitCode: 0 });
+  });
+});

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -54,7 +54,7 @@ describe('Commands.runCommandsGeneral', () => {
       { name: 'test', command: 'echo hi', enabled: true }
     ];
     await Commands.runCommandsGeneral({ configuration: config });
-    expect(Command.default.runCommand).toHaveBeenCalledWith({ command: 'echo hi', parameters: [], timeout: 60000, cwd: undefined });
+    expect(Command.default.runCommand).toHaveBeenCalledWith({ command: 'echo hi', parameters: [], timeout: 60000, cwd: undefined, onStdout: expect.any(Function), onStderr: expect.any(Function) });
   });
 
   test('skips disabled general commands', async () => {
@@ -72,6 +72,6 @@ describe('Commands.runCommandsGeneral', () => {
       { name: 'test', command: 'echo hi', enabled: true, timeout: 500, cwd: '/tmp' }
     ];
     await Commands.runCommandsGeneral({ configuration: config });
-    expect(Command.default.runCommand).toHaveBeenCalledWith({ command: 'echo hi', parameters: [], timeout: 500, cwd: '/tmp' });
+    expect(Command.default.runCommand).toHaveBeenCalledWith({ command: 'echo hi', parameters: [], timeout: 500, cwd: '/tmp', onStdout: expect.any(Function), onStderr: expect.any(Function) });
   });
 });


### PR DESCRIPTION
## Summary
- allow Command.runCommand and runCommandPromise to stream stdout/stderr via optional callbacks while enforcing maxBuffer
- use callbacks for incremental logging of general commands
- add tests that mock a child process to verify streamed output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af4ca4fd608325aa2eab318fd86da6