### PR TITLE
Throw PatchParseError on invalid hex input

### DIFF
--- a/source/lib/patches/parser.ts
+++ b/source/lib/patches/parser.ts
@@ -197,7 +197,9 @@ export namespace Parser {
             return patchObject;
         } catch (error: any) {
             logError(`An error has occurred: ${error}`);
-            throw error;
+            if (error instanceof PatchParseError)
+                throw error;
+            throw new PatchParseError(error?.message ?? String(error));
         }
     }
 }

--- a/source/lib/patches/parser.wrappers.ts
+++ b/source/lib/patches/parser.wrappers.ts
@@ -1,6 +1,8 @@
 import Logger from '../auxiliary/logger.js';
 const { logError } = Logger;
 
+import { PatchParseError } from '../errors/index.js';
+
 export namespace ParserWrappers {
     /**
      *  Parse an integer from an hexadecimal formatted string
@@ -19,14 +21,14 @@ export namespace ParserWrappers {
         try {
             const radix: number = 16;
             const decimalString: number = parseInt(hexString, radix);
-            if (Number.isNaN(decimalString)) {
-                logError(`Invalid hexadecimal string: ${hexString}`);
-                return 0;
-            }
+            if (Number.isNaN(decimalString))
+                throw new PatchParseError(`Invalid hexadecimal string: ${hexString}`);
             return decimalString;
         } catch (error: any) {
             logError(`An error has occurred: ${error}`);
-            return 0;
+            if (error instanceof PatchParseError)
+                throw error;
+            throw new PatchParseError(error?.message ?? String(error));
         }
     }
 

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -80,6 +80,11 @@ describe('Parser.parsePatchFile', () => {
     await expect(Parser.parsePatchFile({ fileData: data })).rejects.toThrow(PatchParseError);
   });
 
+  test('throws for invalid hex values', async () => {
+    const data = '00000000: ZZ 01';
+    await expect(Parser.parsePatchFile({ fileData: data })).rejects.toThrow(PatchParseError);
+  });
+
   test('parses comments and empty lines identically to streaming parser', async () => {
     const data = [
       '',
@@ -104,8 +109,7 @@ describe('Parser.parsePatchFile', () => {
 });
 
 describe('ParserWrappers.hexParse', () => {
-  test('returns 0 for invalid hex strings', () => {
-    const value = ParserWrappers.hexParse({ hexString: 'g1' });
-    expect(value).toBe(0);
+  test('throws for invalid hex strings', () => {
+    expect(() => ParserWrappers.hexParse({ hexString: 'g1' })).toThrow(PatchParseError);
   });
 });


### PR DESCRIPTION
## Summary
- Throw `PatchParseError` when `ParserWrappers.hexParse` receives an invalid hex string
- Propagate parsing errors in `Parser.getPatchObject`
- Test invalid hex strings for wrapper and parser

## Testing
- `npm test` *(fails: Command helpers - parameters › Services commands on Linux)*

------
https://chatgpt.com/codex/tasks/task_e_68bc994cfa1083258a38425433fe8ac9