### PR TITLE
Throw PatchParseError on invalid 64-bit hex strings

### DIFF
--- a/source/lib/patches/parser.wrappers.ts
+++ b/source/lib/patches/parser.wrappers.ts
@@ -41,7 +41,7 @@ export namespace ParserWrappers {
      * hexParseBig({ hexString: 'ffffffff9' });
      * ```
      * result: 68719476729n
-     * @returns BigInt representation of an hexadecimal formatted string or 0n on failure
+     * @returns BigInt representation of an hexadecimal formatted string
      * @since 0.0.2
      */
     export function hexParseBig({ hexString }:
@@ -51,7 +51,9 @@ export namespace ParserWrappers {
             return value;
         } catch (error: any) {
             logError(`An error has occurred: ${error}`);
-            return BigInt(0);
+            if (error instanceof PatchParseError)
+                throw error;
+            throw new PatchParseError(`Invalid hexadecimal string: ${hexString}`);
         }
     }
 

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -85,6 +85,11 @@ describe('Parser.parsePatchFile', () => {
     await expect(Parser.parsePatchFile({ fileData: data })).rejects.toThrow(PatchParseError);
   });
 
+  test('throws for invalid 64-bit hex values', async () => {
+    const data = '00000000: ZZZZZZZZZZZZZZZZ 0000000000000001';
+    await expect(Parser.parsePatchFile({ fileData: data })).rejects.toThrow(PatchParseError);
+  });
+
   test('parses comments and empty lines identically to streaming parser', async () => {
     const data = [
       '',
@@ -111,5 +116,11 @@ describe('Parser.parsePatchFile', () => {
 describe('ParserWrappers.hexParse', () => {
   test('throws for invalid hex strings', () => {
     expect(() => ParserWrappers.hexParse({ hexString: 'g1' })).toThrow(PatchParseError);
+  });
+});
+
+describe('ParserWrappers.hexParseBig', () => {
+  test('throws for invalid hex strings', () => {
+    expect(() => ParserWrappers.hexParseBig({ hexString: 'g1' })).toThrow(PatchParseError);
   });
 });


### PR DESCRIPTION
## Summary
- throw `PatchParseError` from `hexParseBig` when BigInt conversion fails
- fail parsing of 64-bit patch values with invalid hex characters
- test invalid 64-bit hex strings for parser and wrappers

## Testing
- `npm test` *(fails: Command helpers - parameters › Services commands on Linux)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9ec9c1248325b861c695cce1e480