### PR TITLE
feat: add dry run option

### DIFF
--- a/config.json
+++ b/config.json
@@ -16,7 +16,8 @@
         "general"
       ],
       "onlyPackingMode": false,
-      "progressInterval": 0
+      "progressInterval": 0,
+      "dryRun": false
     },
     "patches": {
       "runPatches": true,

--- a/source/lib/commands/commands.ts
+++ b/source/lib/commands/commands.ts
@@ -47,8 +47,24 @@ export namespace Commands {
             logInfo(`Skipping running commands due to configuration`);
             return;
         }
-
-        const { commandsOrder } = configuration.options.general;
+        const { commandsOrder, dryRun } = configuration.options.general;
+        if (dryRun) {
+            logInfo(`Dry run - planned commands:`);
+            const { tasks, services, kill, general } = configuration.commands;
+            for (const task of tasks)
+                if (task.enabled)
+                    logInfo(`Task scheduler command ${task.name}: ${task.command}`);
+            for (const service of services)
+                if (service.enabled)
+                    logInfo(`Service command ${service.command} for ${service.name}`);
+            for (const k of kill)
+                if (k.enabled)
+                    logInfo(`Kill command for ${k.name}`);
+            for (const cmd of general)
+                if (cmd.enabled)
+                    logInfo(`General command ${cmd.name}: ${cmd.command}`);
+            return;
+        }
 
         for (const nextCommand of commandsOrder)
             await runCommandType({ configuration, functionName: nextCommand });

--- a/source/lib/composites.ts
+++ b/source/lib/composites.ts
@@ -127,6 +127,9 @@ export namespace Patcher {
             const fn = compositeMap[functionName];
             if (!fn)
                 throw new Error(`Unknown function: ${functionName}`);
+            const { dryRun } = configuration.options.general;
+            if (dryRun)
+                logInfo(`Dry run enabled - planning ${functionName}`);
             await fn({ configuration });
         } catch (error) {
             logError(`Failed to process function ${error}`);

--- a/source/lib/configuration/configuration.defaults.ts
+++ b/source/lib/configuration/configuration.defaults.ts
@@ -34,7 +34,8 @@ export namespace ConfigurationDefaults {
                         COMMAND_TYPES.GENERAL
                     ],
                     onlyPackingMode: false,
-                    progressInterval: 0
+                    progressInterval: 0,
+                    dryRun: false
                 },
                 patches: {
                     runPatches: true,

--- a/source/lib/configuration/configuration.schema.ts
+++ b/source/lib/configuration/configuration.schema.ts
@@ -15,7 +15,8 @@ export const configurationSchema = {
                         logging: { type: 'boolean' },
                         runningOrder: { type: 'array', items: { type: 'string', enum: Object.values(COMPONENTS) } },
                         commandsOrder: { type: 'array', items: { type: 'string', enum: Object.values(COMMAND_TYPES) } },
-                        onlyPackingMode: { type: 'boolean' }
+                        onlyPackingMode: { type: 'boolean' },
+                        dryRun: { type: 'boolean' }
                     },
                     additionalProperties: true
                 },

--- a/source/lib/configuration/configuration.types.ts
+++ b/source/lib/configuration/configuration.types.ts
@@ -13,7 +13,8 @@ export type ConfigurationObject = {
             commandsOrder: CommandType[] | [],
             onlyPackingMode: boolean,
             /** Interval for emitting progress messages during patching */
-            progressInterval: number
+            progressInterval: number,
+            dryRun: boolean
         },
         patches: {
             runPatches: boolean,

--- a/source/lib/filedrops/filedrops.ts
+++ b/source/lib/filedrops/filedrops.ts
@@ -40,7 +40,15 @@ export namespace Filedrops {
             logInfo(`Skipping filedrops due to configuration`);
             return;
         }
+        const { dryRun } = configuration.options.general;
         const { filedrops } = configuration;
+        if (dryRun) {
+            logInfo(`Dry run - planned filedrops:`);
+            for (const filedrop of filedrops)
+                if (filedrop.enabled)
+                    logInfo(`Would drop ${filedrop.fileDropName} to ${filedrop.fileNamePath}`);
+            return;
+        }
         for (const filedrop of filedrops)
             if (filedrop.enabled)
                 await runFiledrop({ configuration, filedrop });

--- a/source/lib/patches/patches.ts
+++ b/source/lib/patches/patches.ts
@@ -55,8 +55,16 @@ export namespace Patches {
             logInfo(`Skipping running patches due to configuration`);
             return;
         }
-
+        const { dryRun } = configuration.options.general;
         const { patches } = configuration;
+        if (dryRun) {
+            logInfo(`Dry run - planned patches:`);
+            for (const patch of patches)
+                if (patch.enabled)
+                    logInfo(`Would patch ${patch.fileNamePath} using ${patch.patchFilename}`);
+            return;
+        }
+
         for (const patch of patches)
             if (patch.enabled)
                 await runPatch({ configuration, patch });

--- a/test/command.helpers.test.js
+++ b/test/command.helpers.test.js
@@ -143,9 +143,13 @@ describe('Command helpers - parameters', () => {
       parameters: ['disable', 'svc']
     });
     await CommandsServices.remove({ serviceName: 'svc' });
-    expect(Command.default.runCommand).toHaveBeenLastCalledWith({
+    expect(Command.default.runCommand).toHaveBeenNthCalledWith(3, {
       command: 'systemctl',
       parameters: ['disable', '--now', 'svc']
+    });
+    expect(Command.default.runCommand).toHaveBeenLastCalledWith({
+      command: 'systemctl',
+      parameters: ['mask', 'svc']
     });
   });
 

--- a/test/dryrun.test.js
+++ b/test/dryrun.test.js
@@ -1,0 +1,71 @@
+import { jest, describe, test, expect, beforeAll, beforeEach } from '@jest/globals';
+import { ConfigurationDefaults } from '../source/lib/configuration/configuration.defaults.js';
+
+jest.unstable_mockModule('../source/lib/commands/command.js', () => ({
+  default: { runCommand: jest.fn() }
+}));
+
+jest.unstable_mockModule('../source/lib/auxiliary/file.js', () => ({
+  default: {
+    backupFile: jest.fn(),
+    getFileSizeUsingPath: jest.fn(),
+    readBinaryFile: jest.fn(),
+    writeBinaryFile: jest.fn(),
+    createReadStream: jest.fn()
+  }
+}));
+
+jest.unstable_mockModule('../source/lib/patches/parser.js', () => ({
+  default: { parsePatchFile: jest.fn() }
+}));
+
+let Commands;
+let Filedrops;
+let Patches;
+let CommandModule;
+let FileModule;
+let ParserModule;
+
+beforeAll(async () => {
+  Commands = (await import('../source/lib/commands/commands.js')).Commands;
+  Filedrops = (await import('../source/lib/filedrops/filedrops.js')).Filedrops;
+  Patches = (await import('../source/lib/patches/patches.js')).Patches;
+  CommandModule = (await import('../source/lib/commands/command.js')).default;
+  FileModule = (await import('../source/lib/auxiliary/file.js')).default;
+  ParserModule = (await import('../source/lib/patches/parser.js')).default;
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('dry run mode', () => {
+  test('does not execute side effects', async () => {
+    const config = ConfigurationDefaults.getDefaultConfigurationObject();
+    config.options.general.dryRun = true;
+    config.commands.general.push({ name: 'test', command: 'echo test', enabled: true });
+    config.filedrops.push({
+      name: 'drop',
+      fileDropName: 'drop.bin',
+      packedFileName: 'drop.bin',
+      fileNamePath: 'dest.bin',
+      decryptKey: 'key',
+      enabled: true
+    });
+    config.patches.push({
+      name: 'patch',
+      patchFilename: 'patch.patch',
+      fileNamePath: 'file.bin',
+      enabled: true
+    });
+
+    await Commands.runCommands({ configuration: config });
+    await Filedrops.runFiledrops({ configuration: config });
+    await Patches.runPatches({ configuration: config });
+
+    expect(CommandModule.runCommand).not.toHaveBeenCalled();
+    expect(FileModule.writeBinaryFile).not.toHaveBeenCalled();
+    expect(ParserModule.parsePatchFile).not.toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add `dryRun` flag to general configuration options and schema
- skip execution of commands, filedrops and patches when `dryRun` is set
- add tests ensuring dry run leaves no side effects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bcaa4031708325b1cc995d4ce1aae2