### PR TITLE
feat: add logger flush

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -134,6 +134,8 @@ Patcher.patchEmitter.on('progress', console.log);
 
 The logger can prefix each message with an ISO timestamp. Enable timestamps by setting the environment variable `LOG_TIMESTAMPS=true` or by calling `Logger.setConfig({ timestamps: true })`. When not enabled, messages are written without a timestamp.
 
+Call `await Logger.flush()` to wait for pending log writes to finish. The patcher invokes `flush` on shutdown and registers it with `process.on('beforeExit')`, but it can also be awaited manually when embedding the logger elsewhere.
+
 #### Example files
 
 The project comes with an example `.patch` file and a `.dll` file to be packed, these files should be removed and you should add your own files.

--- a/source/lib/auxiliary/logger.ts
+++ b/source/lib/auxiliary/logger.ts
@@ -121,6 +121,10 @@ export namespace Logger {
     export function logError(message: string): void {
         logMessage('error', message, red_bt);
     }
+
+    export async function flush(): Promise<void> {
+        await writeQueue;
+    }
 }
 
 export default Logger;

--- a/source/lib/composites.ts
+++ b/source/lib/composites.ts
@@ -17,7 +17,7 @@ import Uac from './auxiliary/uac.js';
 const { adminCheck } = Uac;
 
 import Logger from './auxiliary/logger.js';
-const { logInfo, logSuccess, logError } = Logger;
+const { logInfo, logSuccess, logError, flush } = Logger;
 import Debug from './auxiliary/debug.js';
 
 import Console from './auxiliary/console.js';
@@ -32,6 +32,8 @@ const {
     COMPONENTS,
     CONFIG_FILEPATH
 } = Constants;
+
+process.on('beforeExit', flush);
 
 export namespace Patcher {
     /**
@@ -80,6 +82,8 @@ export namespace Patcher {
                 logInfo(`Press any key to close application...`);
                 await waitForKeypress();
             }
+
+            await flush();
         }
     }
 


### PR DESCRIPTION
## Summary
- add async `Logger.flush` to drain pending file writes
- ensure patcher awaits log flush and runs it before process exit
- document flushing in logger docs

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c2b0ecef1c8325b2aab335905a924d