### PR TITLE
fix: make tests cross-platform

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@types/node-7z": "^2.1.5",
         "@typescript-eslint/eslint-plugin": "^8.35.0",
         "@typescript-eslint/parser": "^8.35.0",
+        "cross-env": "^10.0.0",
         "eslint": "^9.29.0",
         "jest": "^30.0.2",
         "ts-jest": "^29.1.1",
@@ -583,6 +584,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.8",
@@ -3153,6 +3161,24 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.0.0.tgz",
+      "integrity": "sha512-aU8qlEK/nHYtVuN4p7UQgAwVljzMg8hB4YK5ThRqD2l/ziSnryncPNn7bMLt5cFYsKVKBh8HqLqyCoTupEUu7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@types/node-7z": "^2.1.5",
     "@typescript-eslint/eslint-plugin": "^8.35.0",
     "@typescript-eslint/parser": "^8.35.0",
+    "cross-env": "^10.0.0",
     "eslint": "^9.29.0",
     "jest": "^30.0.2",
     "ts-jest": "^29.1.1",
@@ -61,7 +62,7 @@
     "sea-copy-7z": "node ./dist/buildscripts/copyFiles.js sevenzip",
     "generate-docs": "npx typedoc source/",
     "start": "node ./dist/standalone/executable.js",
-    "test": "npm run ts-build && NODE_OPTIONS=--experimental-vm-modules jest",
+    "test": "npm run ts-build && cross-env NODE_OPTIONS=--experimental-vm-modules jest",
     "lint": "ESLINT_USE_FLAT_CONFIG=false eslint -c .eslintrc.json \"source/**/*.ts\"",
     "typecheck": "tsc --noEmit"
   },


### PR DESCRIPTION
## Summary
- add cross-env dev dependency
- use cross-env in npm test script for Windows compatibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c30ed568788325a7973813deabdc61